### PR TITLE
Fix bug where first entry is not displayed

### DIFF
--- a/autoload/vista/viewer.vim
+++ b/autoload/vista/viewer.vim
@@ -58,7 +58,7 @@ function! s:viewer.render() abort
 
       if !s:ContainWhitespaceOnly(self.prefixes[1]) && try_adjust
         " Adjust the prefix of last item in each scope
-        let tag_colon_num = split(self.rows[-1], ' ')[1:]
+        let tag_colon_num = split(self.rows[-1], ' ')[0:]
         let self.rows[-1] = repeat(' ', self.gap)
               \ .self.prefixes[0]
               \ .join(tag_colon_num, ' ')


### PR DESCRIPTION
If you have a file with one of X (fn, struct, ...) it was displaying as an empty group