### PR TITLE
Implement finding nearest method or function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Vista.vim can also be a symbol navigator similar to [ctrlp-funky](https://github
 - [x] Update automatically when switching between buffers.
 - [x] Update asynchonously in the background when `+job` avaliable.
 - [x] Find the nearest method or function to the cursor, which could be integrated into the statusline.
-- [ ] Highlight current tag/symbol.
+- [ ] Highlight the nearest tag/symbol in the vista sidebar.
 - [ ] Supports all of the languages that ctags does.
 - [ ] Show the visibility (public/private) of tags.
 - [ ] Tree viewer for hierarchy data.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ View and search LSP symbols, tags in Vim/NeoVim.
 
 :warning: **Currently vista.vim is mostly usable, yet not stable. All the public APIs and global options can be changed or even be removed in the future.**
 
+## Table Of Contents
 <!-- TOC GFM -->
 
 * [Introduction](#introduction)
@@ -114,7 +115,9 @@ set statusline+=%{NearestMethodOrFunction()}
 
 Also refer to [liuchengxu/eleline#18](https://github.com/liuchengxu/eleline.vim/pull/18).
 
-![eleline](https://user-images.githubusercontent.com/8850248/54868435-6b90e780-4dc7-11e9-9da9-b9f8fa0b577b.png)
+<p align="center">
+    <img width="800px" src="https://user-images.githubusercontent.com/8850248/54868435-6b90e780-4dc7-11e9-9da9-b9f8fa0b577b.png">
+</p>
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ View and search LSP symbols, tags in Vim/NeoVim.
         * [Vim 8](#vim-8)
         * [NeoVim](#neovim)
 * [Usage](#usage)
+    * [Show the nearest method/function in the statusline](#show-the-nearest-methodfunction-in-the-statusline)
     * [Commands](#commands)
     * [Options](#options)
 * [Contributing](#contributing)
@@ -47,14 +48,15 @@ Vista.vim can also be a symbol navigator similar to [ctrlp-funky](https://github
 - [x] Jump to the tag/symbol from vista sidebar with a blink.
 - [x] Update automatically when switching between buffers.
 - [x] Update asynchonously in the background when `+job` avaliable.
-- [ ] Supports all of the languages that ctags does.
+- [x] Find the nearest method or function to the cursor, which could be integrated into the statusline.
 - [ ] Highlight current tag/symbol.
+- [ ] Supports all of the languages that ctags does.
 - [ ] Show the visibility (public/private) of tags.
 - [ ] Tree viewer for hierarchy data.
 
 Notes:
 
-- The feature of finder in vista.vim `:Vista finder [EXECUTIVE]` is a bit like `:BTags` or `:Tags` in [fzf.vim](https://github.com/junegunn/fzf.vim), `:CocList` in [coc.nvim](https://github.com/neoclide/coc.nvim), `:LeaderfBufTag` in [leaderf.vim](https://github.com/Yggdroot/LeaderF), etc. You can choose whichever you like.
+- The feature of finder in vista.vim `:Vista finder [EXECUTIVE]` is a bit like `:BTags` or `:Tags` in [fzf.vim](https://github.com/junegunn/fzf.vim), `:CocList` in [coc.nvim](https://github.com/neoclide/coc.nvim), `:LeaderfBufTag` in [leaderf.vim](https://github.com/Yggdroot/LeaderF), etc. You can choose whatever you like.
 
 - I personally don't use all the features I have listed. Hence some of them may be on the TODOs forever :(.
 
@@ -97,6 +99,22 @@ $ git clone https://github.com/liuchengxu/vista.vim.git --depth=1 ~/.local/share
 ## Usage
 
 :warning: The following instructions are not complete, **please see the help via `:help vista` for more detailed usage**.
+
+### Show the nearest method/function in the statusline
+
+You can do the following to show the nearest method/function in your statusline:
+
+```vim
+function! NearestMethodOrFunction() abort
+  return get(b:, 'vista_nearest_method_or_function', '')
+endfunction
+
+set statusline+=%{NearestMethodOrFunction()}
+```
+
+Also refer to [liuchengxu/eleline#18](https://github.com/liuchengxu/eleline.vim/pull/18).
+
+![eleline](https://user-images.githubusercontent.com/8850248/54868435-6b90e780-4dc7-11e9-9da9-b9f8fa0b577b.png)
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 View and search LSP symbols, tags in Vim/NeoVim.
 
+![vista](https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif)
+
 :warning: **Currently vista.vim is mostly usable, yet not stable. All the public APIs and global options can be changed or even be removed in the future.**
 
 ## Table Of Contents

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 View and search LSP symbols, tags in Vim/NeoVim.
 
-![vista](https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif)
+<p align="center">
+    <img width="800px" src="https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif">
+</p>
 
 :warning: **Currently vista.vim is mostly usable, yet not stable. All the public APIs and global options can be changed or even be removed in the future.**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 View and search LSP symbols, tags in Vim/NeoVim.
 
 <p align="center">
-    <img width="800px" src="https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif">
+    <img width="700px" src="https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif">
 </p>
 
 :warning: **Currently vista.vim is mostly usable, yet not stable. All the public APIs and global options can be changed or even be removed in the future.**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 View and search LSP symbols, tags in Vim/NeoVim.
 
 <p align="center">
-    <img width="700px" src="https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif">
+    <img width="600px" src="https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif">
 </p>
 
 :warning: **Currently vista.vim is mostly usable, yet not stable. All the public APIs and global options can be changed or even be removed in the future.**

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -212,12 +212,13 @@ function! vista#cursor#FindNearestMethodOrFunction() abort
   endif
 
   if empty(t:vista.functions)
+    call setbufvar(t:vista.source.bufnr, 'vista_nearest_method_or_function', '')
     return
   endif
 
   call s:StopFindTimer()
 
-  let delay = get(g:, 'vista_find_nearest_method_or_function_delay', 400)
+  let delay = get(g:, 'vista_find_nearest_method_or_function_delay', 300)
   let s:find_timer = timer_start(
         \ delay,
         \ function('s:FindNearestMethodOrFunction'),

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -211,6 +211,10 @@ function! vista#cursor#FindNearestMethodOrFunction() abort
     return
   endif
 
+  if empty(t:vista.functions)
+    return
+  endif
+
   call s:StopFindTimer()
 
   let delay = get(g:, 'vista_find_nearest_method_or_function_delay', 400)

--- a/autoload/vista/executive/coc.vim
+++ b/autoload/vista/executive/coc.vim
@@ -14,6 +14,7 @@ function! s:Extract(symbols) abort
   endif
 
   let s:data = {}
+  let t:vista.functions = []
   call map(a:symbols, 'vista#parser#lsp#ExtractSymbol(v:val, s:data)')
 
   if empty(s:data)

--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -115,6 +115,7 @@ endfunction
 
 function! s:close_cb(channel)
   let s:data = {}
+  let t:vista.functions = []
 
   while ch_status(a:channel, {'part': 'out'}) ==# 'buffered'
     let line = ch_read(a:channel)
@@ -145,6 +146,7 @@ endfunction
 
 function! s:ExtractLinewise(raw_data) abort
   let s:data = {}
+  let t:vista.functions = []
   call map(a:raw_data, 'call(s:TagParser, [v:val, s:data])')
 endfunction
 

--- a/autoload/vista/executive/lcn.vim
+++ b/autoload/vista/executive/lcn.vim
@@ -22,6 +22,7 @@ function s:Handler(output) abort
   call map(result, 'vista#parser#lsp#FromKindToSymbol(v:val, lines)')
 
   let s:data = {}
+  let t:vista.functions = []
   call map(lines, 'vista#parser#lsp#ExtractSymbol(v:val, s:data)')
 
   let s:fetching = v:false

--- a/autoload/vista/executive/vim_lsp.vim
+++ b/autoload/vista/executive/vim_lsp.vim
@@ -21,6 +21,7 @@ function! s:Handler(_server, _req_id, _type, data) abort
   call map(result, 'vista#parser#lsp#FromKindToSymbol(v:val, lines)')
 
   let s:data = {}
+  let t:vista.functions = []
   call map(lines, 'vista#parser#lsp#ExtractSymbol(v:val, s:data)')
 
   let s:fetching = v:false

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -27,6 +27,10 @@ function! vista#parser#ctags#ExtractTag(line, container) abort
 
   let picked = {'lnum': lnum, 'text': tagname}
 
+  if scope ==? 'function' || scope ==? 'func'
+    call add(t:vista.functions, picked)
+  endif
+
   if has_key(a:container, scope)
     call add(a:container[scope], picked)
   else
@@ -40,6 +44,10 @@ function! vista#parser#ctags#TagFromJSON(line, container) abort
   let kind = line.kind
 
   let picked = {'lnum': line.line, 'text': line.name }
+
+  if kind ==? 'function' || kind ==? 'func'
+    call add(t:vista.functions, picked)
+  endif
 
   if has_key(a:container, kind)
     call add(a:container[kind], picked)

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -2,6 +2,14 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
+function! s:Insert(container, kind, picked) abort
+  if has_key(a:container, a:kind)
+    call add(a:container[a:kind], a:picked)
+  else
+    let a:container[a:kind] = [a:picked]
+  endif
+endfunction
+
 " Parse the output from ctags linewise and feed them into the container
 " The parsed result should be compatible with the LSP output.
 "
@@ -27,15 +35,11 @@ function! vista#parser#ctags#ExtractTag(line, container) abort
 
   let picked = {'lnum': lnum, 'text': tagname}
 
-  if scope ==? 'function' || scope ==? 'func'
+  if scope =~# '^f'
     call add(t:vista.functions, picked)
   endif
 
-  if has_key(a:container, scope)
-    call add(a:container[scope], picked)
-  else
-    let a:container[scope] = [picked]
-  endif
+  call s:Insert(a:container, scope, picked)
 endfunction
 
 function! vista#parser#ctags#TagFromJSON(line, container) abort
@@ -49,11 +53,7 @@ function! vista#parser#ctags#TagFromJSON(line, container) abort
     call add(t:vista.functions, picked)
   endif
 
-  if has_key(a:container, kind)
-    call add(a:container[kind], picked)
-  else
-    let a:container[kind] = [picked]
-  endif
+  call s:Insert(a:container, kind, picked)
 endfunction
 
 function! vista#parser#ctags#ProjectTagFromXformat(line, container) abort
@@ -85,11 +85,7 @@ function! vista#parser#ctags#ProjectTagFromXformat(line, container) abort
 
   let picked = {'lnum': lnum, 'text': tagname, 'tagfile': relpath, 'taginfo': pattern[2:-3]}
 
-  if has_key(a:container, kind)
-    call add(a:container[kind], picked)
-  else
-    let a:container[kind] = [picked]
-  endif
+  call s:Insert(a:container, kind, picked)
 endfunction
 
 function! vista#parser#ctags#ProjectTagFromJSON(line, container) abort
@@ -107,9 +103,5 @@ function! vista#parser#ctags#ProjectTagFromJSON(line, container) abort
 
   let picked = {'lnum': line.line, 'text': line.name, 'tagfile': line.path, 'taginfo': line.pattern[2:-3]}
 
-  if has_key(a:container, kind)
-    call add(a:container[kind], picked)
-  else
-    let a:container[kind] = [picked]
-  endif
+  call s:Insert(a:container, kind, picked)
 endfunction

--- a/autoload/vista/parser/lsp.vim
+++ b/autoload/vista/parser/lsp.vim
@@ -58,12 +58,15 @@ function! vista#parser#lsp#FromKindToSymbol(line, container) abort
   endif
 endfunction
 
-
 " https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
 function! vista#parser#lsp#ExtractSymbol(symbol, container) abort
   let symbol = a:symbol
 
   let picked = {'lnum': symbol.lnum, 'col': symbol.col, 'text': symbol.text}
+
+  if symbol.kind ==? 'Method' || symbol.kind ==? 'Function'
+    call add(t:vista.functions, symbol)
+  endif
 
   if has_key(a:container, symbol.kind)
     call add(a:container[symbol.kind], picked)

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -149,6 +149,10 @@ function! vista#util#BinarySearch(array, target) abort
     endif
   endwhile
 
+  if low == 0
+    return ''
+  endif
+
   " If no exact match, prefer the previous nearest one.
   if get(g:, 'vista_find_absolute_nearest_method_or_function', 0)
     if abs(array[low].lnum - target) < abs(array[low - 1].lnum - target)

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -128,3 +128,37 @@ function! vista#util#LowerIndentLineNr() abort
   endwhile
   return 0
 endfunction
+
+" array: List of Method or Function symbols
+" target: current line number in the source buffer
+function! vista#util#BinarySearch(array, target) abort
+  let [array, target] = [a:array, a:target]
+
+  let low = 0
+  let high = len(array) - 1
+
+  while low <= high
+    let mid = (low + high) / 2
+    if array[mid].lnum == target
+      let found = array[mid]
+      return found.text
+    elseif array[mid].lnum > target
+      let high = mid - 1
+    else
+      let low = mid + 1
+    endif
+  endwhile
+
+  " If no exact match, prefer the previous nearest one.
+  if get(g:, 'vista_find_absolute_nearest_method_or_function', 0)
+    if abs(array[low].lnum - target) < abs(array[low - 1].lnum - target)
+      let found = array[low]
+    else
+      let found = array[low - 1]
+    endif
+  else
+    let found = array[low - 1]
+  endif
+
+  return found.text
+endfunction

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -59,6 +59,8 @@ FEATURES                                                          *vista-feature
 *   [x] Jump to the tag/symbol from vista sidebar with a blink.
 *   [x] Update automatically when switching between buffers.
 *   [x] Update asynchonously in the background when `+job` avaliable.
+*   [x] Find the nearest method or function to the cursor, which could be
+    integrated into the statusline.
 *   [ ] Supports all of the languages that ctags does.
 *   [ ] Highlight current tag/symbol.
 *   [ ] Show the visibility (public/private) of tags.

--- a/ftplugin/vista.vim
+++ b/ftplugin/vista.vim
@@ -37,9 +37,10 @@ nnoremap <buffer> <silent> q    :close<CR>
 nnoremap <buffer> <silent> <CR> :<c-u>call vista#cursor#FoldOrJump()<CR>
 nnoremap <buffer> <silent> /    :<c-u>call vista#finder#fzf#Run()<CR>
 
-if get(g:, 'vista_echo_cursor', 1)
-  augroup VistaCursor
-    autocmd!
+augroup VistaCursor
+  autocmd!
+  if get(g:, 'vista_echo_cursor', 1)
     autocmd CursorMoved <buffer> call vista#cursor#ShowDetailWithDelay()
-  augroup END
-endif
+  endif
+  autocmd CursorMoved * call vista#cursor#FindNearestMethodOrFunction()
+augroup END


### PR DESCRIPTION

![vista](https://user-images.githubusercontent.com/8850248/54874346-88a7d380-4e24-11e9-8574-fb4c56085e9d.gif)

<img width="1680" alt="屏幕快照 2019-03-23 下午8 03 25" src="https://user-images.githubusercontent.com/8850248/54865843-e09ff500-4da6-11e9-8fb0-b4850ffc26ee.png">

## Show the nearest method/function in the statusline

```vim
function! NearestMethodOrFunction() abort
  return exists('b:vista_nearest_method_or_function') ? b:vista_nearest_method_or_function : ''
endfunction

set statusline+=%{NearestMethodOrFunction()}
```

Also refer to https://github.com/liuchengxu/eleline.vim/pull/18.