### PR TITLE
Provide default renderer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,17 @@ the issue may be closed as unreproducible. Thanks. -->
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**Steps to reproduce**
+**Environment:**
+- OS: <!-- e.g. Mac OS, Ubuntu 18.04, Windows 10 -->
+- Vim/Neovim version: <!-- first two lines of `:version` command output -->
+- This plugin version: <!-- output of `git rev-parse origin/master` command -->
+
+**Minimal vimrc to reproduce**
+
+```vim
+```
+
+**Steps to reproduce given the above minimal vimrc**
 <!-- short descriptions of actions, which lead towards the issue -->
 1.
 2.
@@ -25,8 +35,3 @@ A clear and concise description of what actually happens.
 
 **Screenshot or gif** (if possible)
 If applicable, add screenshots to help explain your problem.
-
-**Environment:**
-- OS: <!-- e.g. Mac OS, Ubuntu 18.04, Windows 10 -->
-- Vim/Neovim version: <!-- first two lines of `:version` command output -->
-- This plugin version: <!-- output of `git rev-parse origin/master` command -->

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ autocmd VimEnter * call vista#RunForNearestMethodOrFunction()
 Also refer to [liuchengxu/eleline#18](https://github.com/liuchengxu/eleline.vim/pull/18).
 
 <p align="center">
-    <img width="800px" src="https://user-images.githubusercontent.com/8850248/54868435-6b90e780-4dc7-11e9-9da9-b9f8fa0b577b.png">
+    <img width="800px" src="https://user-images.githubusercontent.com/8850248/55477900-da363680-564c-11e9-8e71-845260f3d44b.png">
 </p>
 
 ### Commands

--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -74,6 +74,7 @@ function! vista#(bang, ...) abort
         call vista#cursor#ShowTag()
       else
         call vista#sidebar#Open()
+        let t:vista.lnum = line('.')
       endif
     else
       return vista#error#Expect("Vista [finder] [EXECUTIVE]")

--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -69,6 +69,12 @@ function! vista#(bang, ...) abort
       call vista#finder#fzf#Run('coc')
     elseif a:1 == 'finder!'
       call vista#finder#fzf#ProjectRun()
+    elseif a:1 == 'show'
+      if vista#sidebar#IsVisible()
+        call vista#cursor#ShowTag()
+      else
+        call vista#sidebar#Open()
+      endif
     else
       return vista#error#Expect("Vista [finder] [EXECUTIVE]")
     endif

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -2,21 +2,26 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-let s:cursor_timer = -1
 let s:find_timer = -1
+let s:cursor_timer = -1
+let s:highlight_timer = -1
+
+let s:last_vlnum = -1
+
+function! s:GenericStopTimer(timer) abort
+  execute 'if '.a:timer.' != -1 | call timer_stop('.a:timer.') | let 'a:timer.' = -1 | endif'
+endfunction
 
 function! s:StopFindTimer() abort
-  if s:find_timer != -1
-    call timer_stop(s:find_timer)
-    let s:find_timer = -1
-  endif
+  call s:GenericStopTimer('s:find_timer')
 endfunction
 
 function! s:StopCursorTimer() abort
-  if s:cursor_timer != -1
-    call timer_stop(s:cursor_timer)
-    let s:cursor_timer = -1
-  endif
+  call s:GenericStopTimer('s:cursor_timer')
+endfunction
+
+function! s:StopHighlightTimer() abort
+  call s:GenericStopTimer('s:highlight_timer')
 endfunction
 
 " Get tag and corresponding source line at current cursor position.
@@ -30,7 +35,7 @@ function! s:GetInfoUnderCursor() abort
 
   let lnum = cur_line[-1]
 
-  let source_line = vista#source#Line(lnum)
+  let source_line = t:vista.source.line(lnum)
   if empty(source_line)
     return [v:null, v:null]
   endif
@@ -114,36 +119,6 @@ function! s:ShowDetail() abort
   endif
 endfunction
 
-function! vista#cursor#ShowDetail(_timer) abort
-  let cur_line = getline('.')
-  if empty(cur_line)
-    return
-  endif
-
-  " scope line
-  if cur_line[-1:] ==# ']'
-    let splitted = split(cur_line)
-    " Join the scope parts in case of they contains spaces, e.g., structure names
-    let scope = join(splitted[1:-2], ' ')
-    let cnt = matchstr(splitted[-1], '\d\+')
-    echohl Keyword  | echo '['.scope.']: ' | echohl NONE
-    echohl Function | echon cnt          | echohl NONE
-    return
-  endif
-
-  call s:ShowDetail()
-endfunction
-
-function! vista#cursor#ShowDetailWithDelay() abort
-  call s:StopCursorTimer()
-
-  let delay = get(g:, 'vista_cursor_delay', 400)
-  let s:cursor_timer = timer_start(
-        \ delay,
-        \ function('vista#cursor#ShowDetail'),
-        \ )
-endfunction
-
 function! s:Jump() abort
   let cur_line = split(getline('.'), ':')
 
@@ -175,6 +150,64 @@ function! s:Jump() abort
   endif
 endfunction
 
+function! s:Compare(s1, s2) abort
+  return a:s1.lnum - a:s2.lnum
+endfunction
+
+function! s:FindNearestMethodOrFunction(_timer) abort
+  call sort(t:vista.functions, function('s:Compare'))
+  let result = vista#util#BinarySearch(t:vista.functions, line('.'), 'lnum', 'text')
+  call setbufvar(t:vista.source.bufnr, 'vista_nearest_method_or_function', result)
+
+  call s:StopHighlightTimer()
+  let s:highlight_timer = timer_start(200, function('s:HighlightNearestTag'))
+endfunction
+
+function! s:ExistsVlnum() abort
+  return exists('t:vista')
+        \ && has_key(t:vista, 'raw')
+        \ && !empty(t:vista.raw)
+        \ && has_key(t:vista.raw[0], 'vlnum')
+endfunction
+
+function! s:HighlightNearestTag(_timer) abort
+  if vista#ShouldSkip() || !s:ExistsVlnum()
+    return
+  endif
+
+  let s:vlnum = vista#util#BinarySearch(t:vista.raw, line('.'), 'line', 'vlnum')
+
+  if empty(s:vlnum)
+    return
+  endif
+
+  " If the vlnum is same with previous one
+  if s:last_vlnum == s:vlnum
+    return
+  endif
+
+  let s:last_vlnum = s:vlnum
+
+  let winnr = bufwinnr('__vista__')
+  if winnr() != winnr
+    execute winnr.'wincmd w'
+    let l:switch_back = 1
+  endif
+
+  if exists('w:highlight_id')
+    call matchdelete(w:highlight_id)
+    unlet w:highlight_id
+  endif
+
+  let w:highlight_id = matchaddpos('Search', [s:vlnum])
+
+  execute 'normal!' s:vlnum.'z.'
+
+  if exists('l:switch_back')
+    wincmd p
+  endif
+endfunction
+
 " Fold scope based on the indent.
 " Jump to the target source line or source file.
 function! vista#cursor#FoldOrJump() abort
@@ -184,6 +217,7 @@ function! vista#cursor#FoldOrJump() abort
   endif
 
   " Fold or unfold when meets scope line
+  " FIXME this only work for the kind renderer.
   if getline('.') =~ ']$'
     if foldclosed('.') != -1
       normal! zo
@@ -196,35 +230,70 @@ function! vista#cursor#FoldOrJump() abort
   call s:Jump()
 endfunction
 
-function! s:Compare(s1, s2) abort
-  return a:s1.lnum - a:s2.lnum
-endfunction
-
-function! s:FindNearestMethodOrFunction(_timer) abort
-  call sort(t:vista.functions, function('s:Compare'))
-  let result = vista#util#BinarySearch(t:vista.functions, line('.'))
-  call setbufvar(t:vista.source.bufnr, 'vista_nearest_method_or_function', result)
-endfunction
-
 function! vista#cursor#FindNearestMethodOrFunction() abort
-  if !exists('t:vista') || !has_key(t:vista, 'functions')
+  if !exists('t:vista') || !has_key(t:vista, 'functions') || bufnr('') != t:vista.source.bufnr
     return
   endif
 
-  if bufnr('') != t:vista.source.bufnr
-    return
-  endif
+  call s:StopFindTimer()
 
   if empty(t:vista.functions)
     call setbufvar(t:vista.source.bufnr, 'vista_nearest_method_or_function', '')
     return
   endif
 
-  call s:StopFindTimer()
-
   let delay = get(g:, 'vista_find_nearest_method_or_function_delay', 300)
   let s:find_timer = timer_start(
         \ delay,
         \ function('s:FindNearestMethodOrFunction'),
         \ )
+endfunction
+
+function! vista#cursor#ShowDetail(_timer) abort
+  let cur_line = getline('.')
+  if empty(cur_line)
+    return
+  endif
+
+  " scope line
+  if cur_line[-1:] ==# ']'
+    let splitted = split(cur_line)
+    " Join the scope parts in case of they contains spaces, e.g., structure names
+    let scope = join(splitted[1:-2], ' ')
+    let cnt = matchstr(splitted[-1], '\d\+')
+    echohl Keyword  | echo '['.scope.']: ' | echohl NONE
+    echohl Function | echon cnt          | echohl NONE
+    return
+  endif
+
+  call s:ShowDetail()
+endfunction
+
+function! vista#cursor#ShowDetailWithDelay() abort
+  call s:StopCursorTimer()
+
+  let delay = get(g:, 'vista_cursor_delay', 400)
+  let s:cursor_timer = timer_start(
+        \ delay,
+        \ function('vista#cursor#ShowDetail'),
+        \ )
+endfunction
+
+function! vista#cursor#ShowTag() abort
+  if !s:ExistsVlnum()
+    return
+  endif
+
+  let s:vlnum = vista#util#BinarySearch(t:vista.raw, line('.'), 'line', 'vlnum')
+
+  if empty(s:vlnum)
+    return
+  endif
+
+  if winnr() != winnr
+    execute winnr.'wincmd w'
+  endif
+
+  call cursor(s:vlnum, 1)
+  normal! zz
 endfunction

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -288,6 +288,10 @@ endfunction
 
 " This happens on calling `:Vista show` but the vista window is still invisible.
 function! vista#cursor#ShowTagFor(lnum) abort
+  if !s:ExistsVlnum()
+    return
+  endif
+
   let s:vlnum = vista#util#BinarySearch(t:vista.raw, a:lnum, 'line', 'vlnum')
   if empty(s:vlnum)
     return

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -293,6 +293,8 @@ function! vista#cursor#ShowTag() abort
     return
   endif
 
+  let winnr = t:vista.winnr()
+
   if winnr() != winnr
     execute winnr.'wincmd w'
   endif

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -160,7 +160,10 @@ function! s:FindNearestMethodOrFunction(_timer) abort
   call setbufvar(t:vista.source.bufnr, 'vista_nearest_method_or_function', result)
 
   call s:StopHighlightTimer()
-  let s:highlight_timer = timer_start(200, function('s:HighlightNearestTag'))
+
+  if vista#sidebar#IsVisible()
+    let s:highlight_timer = timer_start(200, function('s:HighlightNearestTag'))
+  endif
 endfunction
 
 function! s:ExistsVlnum() abort
@@ -194,12 +197,12 @@ function! s:HighlightNearestTag(_timer) abort
     let l:switch_back = 1
   endif
 
-  if exists('w:highlight_id')
-    call matchdelete(w:highlight_id)
-    unlet w:highlight_id
+  if exists('w:vista_highlight_id')
+    call matchdelete(w:vista_highlight_id)
+    unlet w:vista_highlight_id
   endif
 
-  let w:highlight_id = matchaddpos('Search', [s:vlnum])
+  let w:vista_highlight_id = matchaddpos('Search', [s:vlnum])
 
   execute 'normal!' s:vlnum.'z.'
 

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -173,6 +173,17 @@ function! s:ExistsVlnum() abort
         \ && has_key(t:vista.raw[0], 'vlnum')
 endfunction
 
+function! s:ApplyHighlight(lnum) abort
+  if exists('w:vista_highlight_id')
+    call matchdelete(w:vista_highlight_id)
+    unlet w:vista_highlight_id
+  endif
+
+  let w:vista_highlight_id = matchaddpos('Search', [a:lnum])
+
+  execute 'normal!' s:vlnum.'z.'
+endfunction
+
 function! s:HighlightNearestTag(_timer) abort
   if vista#ShouldSkip() || !s:ExistsVlnum()
     return
@@ -197,14 +208,7 @@ function! s:HighlightNearestTag(_timer) abort
     let l:switch_back = 1
   endif
 
-  if exists('w:vista_highlight_id')
-    call matchdelete(w:vista_highlight_id)
-    unlet w:vista_highlight_id
-  endif
-
-  let w:vista_highlight_id = matchaddpos('Search', [s:vlnum])
-
-  execute 'normal!' s:vlnum.'z.'
+  call s:ApplyHighlight(s:vlnum)
 
   if exists('l:switch_back')
     wincmd p
@@ -280,6 +284,16 @@ function! vista#cursor#ShowDetailWithDelay() abort
         \ delay,
         \ function('vista#cursor#ShowDetail'),
         \ )
+endfunction
+
+" This happens on calling `:Vista show` but the vista window is still invisible.
+function! vista#cursor#ShowTagFor(lnum) abort
+  let s:vlnum = vista#util#BinarySearch(t:vista.raw, a:lnum, 'line', 'vlnum')
+  if empty(s:vlnum)
+    return
+  endif
+
+  call s:ApplyHighlight(s:vlnum)
 endfunction
 
 function! vista#cursor#ShowTag() abort

--- a/autoload/vista/executive/coc.vim
+++ b/autoload/vista/executive/coc.vim
@@ -7,14 +7,19 @@ let s:provider = fnamemodify(expand('<sfile>'), ':t:r')
 let s:reload_only = v:false
 let s:should_display = v:false
 
+function! s:PrepareContainer() abort
+  let s:data = {}
+  let t:vista.functions = []
+  let t:vista.raw = []
+endfunction
+
 " Extract fruitful infomation from raw symbols
 function! s:Extract(symbols) abort
   if empty(a:symbols)
     return
   endif
 
-  let s:data = {}
-  let t:vista.functions = []
+  call s:PrepareContainer()
   call map(a:symbols, 'vista#parser#lsp#ExtractSymbol(v:val, s:data)')
 
   if empty(s:data)

--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -80,6 +80,8 @@ endfunction
 function! s:close_cb(channel)
   let s:data = {}
   let t:vista.functions = []
+  let t:vista.raw = []
+  let t:vista.kinds = []
 
   while ch_status(a:channel, {'part': 'out'}) ==# 'buffered'
     let line = ch_read(a:channel)
@@ -111,6 +113,8 @@ endfunction
 function! s:ExtractLinewise(raw_data) abort
   let s:data = {}
   let t:vista.functions = []
+  let t:vista.raw = []
+  let t:vista.kinds = []
   call map(a:raw_data, 'call(s:TagParser, [v:val, s:data])')
 endfunction
 
@@ -157,13 +161,13 @@ endfunction
 " This idea comes from tagbar.
 function! s:IntoTemp(...) abort
   let tmp = tempname()
-  let ext = vista#source#Extension()
+  let ext = t:vista.source.extension()
   if ext != ''
     let tmp = join([tmp, ext], '.')
   endif
 
   if empty(a:1)
-    let lines = vista#source#Lines()
+    let lines = t:vista.source.lines()
   else
     try
       let lines = readfile(a:1)

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -83,7 +83,7 @@ function! s:AlignSource() abort
 
   for [kind, v] in items(s:data)
     for item in v
-      let line = vista#source#Line(item.lnum)
+      let line = t:vista.source.line(item.lnum)
       let lnum_and_text = printf("%s:%s", item.lnum, item.text)
       let row = printf("%s%s\t[%s]%s\t%s",
             \ lnum_and_text, repeat(' ', max_len_lnum_and_text- strwidth(lnum_and_text)),

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -66,6 +66,9 @@ function! s:ParseTagfield(tagfields) abort
     let fields.kind = value
   else
     let fields.kind = s:ShortToLong(a:tagfields[0])
+    if index(t:vista.kinds, kind) == -1
+      call add(t:vista.kinds, kind)
+    endif
   endif
 
   if len(a:tagfields) > 1
@@ -114,6 +117,8 @@ endfunction
 function! vista#parser#ctags#FromJSON(line, container) abort
   let line = json_decode(a:line)
 
+  call add(t:vista.raw, line)
+
   let kind = line.kind
 
   let picked = {'lnum': line.line, 'text': line.name }
@@ -123,6 +128,10 @@ function! vista#parser#ctags#FromJSON(line, container) abort
       let picked.signature = line.signature
     endif
     call add(t:vista.functions, picked)
+  endif
+
+  if index(t:vista.kinds, kind) == -1
+    call add(t:vista.kinds, kind)
   endif
 
   call s:Insert(a:container, kind, picked)

--- a/autoload/vista/renderer/default.vim
+++ b/autoload/vista/renderer/default.vim
@@ -4,8 +4,6 @@
 
 let s:scope_icon = ['⊕', '⊖']
 
-let s:last_kind = 'DOES_NOT_EXIST'
-
 let s:visibility_icon = {
       \ 'public': '+',
       \ 'protected': '#',
@@ -28,7 +26,7 @@ function! s:RenderLinewise() abort
       let access = ''
     endif
 
-    if has_key(line, 'kind') && s:last_kind != line.kind
+    if !exists('s:last_kind') || has_key(line, 'kind') && s:last_kind != line.kind
       call add(rows, line.kind)
       let s:last_kind = get(line, 'kind')
       continue
@@ -51,6 +49,8 @@ function! s:RenderLinewise() abort
 
     let idx += 1
   endwhile
+
+  unlet s:last_kind
 
   return rows
 endfunction

--- a/autoload/vista/renderer/default.vim
+++ b/autoload/vista/renderer/default.vim
@@ -2,6 +2,63 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
+let s:scope_icon = ['⊕', '⊖']
+
+let s:last_kind = 'DOES_NOT_EXIST'
+
+let s:visibility_icon = {
+      \ 'public': '+',
+      \ 'protected': '#',
+      \ 'private': '-',
+      \ }
+
+function! s:RenderLinewise() abort
+  let rows = []
+
+  " FIXME the same kind tags could be in serveral sections
+  let idx = 0
+  let raw_len = len(t:vista.raw)
+
+  while idx < raw_len
+    let line = t:vista.raw[idx]
+
+    if has_key(line, 'access')
+      let access = get(s:visibility_icon, line.access, '?')
+    else
+      let access = ''
+    endif
+
+    if has_key(line, 'kind') && s:last_kind != line.kind
+      call add(rows, line.kind)
+      let s:last_kind = get(line, 'kind')
+      continue
+    endif
+
+    let row = vista#util#Join('  '.access, get(line, 'name'), get(line, 'signature', ''), ':'.line.line)
+
+    call add(rows, row)
+
+    " Inject vlnum.
+    " Since we prepend the fpath and a blank line, the vlnum should plus 2.
+    let line.vlnum = len(rows) + 2
+
+    " Append a blank line in the last of a section.
+    if has_key(line, 'kind') && idx < raw_len - 1
+      if line.kind != get(t:vista.raw[idx+1], 'kind')
+        call add(rows, '')
+      endif
+    endif
+
+    let idx += 1
+  endwhile
+
+  return rows
+endfunction
+
 function! vista#renderer#default#Render() abort
-  echoerr 'Unimplemented!'
+  if empty(t:vista.raw)
+    return []
+  endif
+
+  return s:RenderLinewise()
 endfunction

--- a/autoload/vista/renderer/kind.vim
+++ b/autoload/vista/renderer/kind.vim
@@ -30,10 +30,6 @@ function! s:ContainWhitespaceOnly(str) abort
   return a:str !~ '\S'
 endfunction
 
-function! s:Join(...) abort
-  return join(a:000, '')
-endfunction
-
 function! s:viewer.render() abort
   let try_adjust = self.prefixes[0] != self.prefixes[1]
 
@@ -49,7 +45,7 @@ function! s:viewer.render() abort
       " Children
       for i in v
         if len(i) > 0
-          let row = s:Join(
+          let row = vista#util#Join(
                 \ repeat(' ', self.gap),
                 \ self.prefixes[1],
                 \ i.text,
@@ -77,14 +73,10 @@ function! s:viewer.render() abort
   return self.rows
 endfunction
 
-function! s:Render(data) abort
+function! vista#renderer#kind#Render(data) abort
   if empty(a:data)
     return []
   endif
   call s:viewer.init(a:data)
   return s:viewer.render()
-endfunction
-
-function! vista#renderer#kind#Render(data) abort
-  return s:Render(a:data)
 endfunction

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -152,12 +152,12 @@ function! vista#sidebar#Open() abort
   call vista#executive#{executive}#Execute(v:false, v:true, v:false)
 endfunction
 
-function! s:IsVisible() abort
+function! vista#sidebar#IsVisible() abort
   return bufwinnr('__vista__') != -1
 endfunction
 
 function! vista#sidebar#Toggle() abort
-  if s:IsVisible()
+  if vista#sidebar#IsVisible()
     call vista#sidebar#Close()
   else
     call vista#sidebar#Open()

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -33,25 +33,8 @@ function! vista#sidebar#Reload(data) abort
     return
   endif
 
-  let winnr = t:vista.winnr()
-
-  " Abort if can't find vista window
-  if winnr == -1
-    return
-  endif
-
-  let switch_in = winnr() != winnr
-
-  if switch_in
-    noautocmd execute winnr."wincmd w"
-  endif
-
   let rendered = vista#viewer#Render(a:data)
   call vista#util#SetBufline(t:vista.bufnr, rendered)
-
-  if switch_in
-    wincmd p
-  endif
 endfunction
 
 " Open or update vista buffer given the rendered rows.
@@ -97,6 +80,23 @@ function! vista#sidebar#Close() abort
     unlet t:vista.bufnr
   endif
 
+  " let winnr = t:vista.winnr()
+
+  " " Abort if can't find vista window
+  " if winnr == -1
+    " return
+  " endif
+
+  " let switch_in = winnr() != winnr
+
+  " if switch_in
+    " noautocmd execute winnr."wincmd w"
+  " endif
+
+  " if switch_in
+    " wincmd p
+  " endif
+  "
   if exists('t:vista.winnr')
     let winnr = t:vista.winnr()
     noautocmd execute winnr.'wincmd w'

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -98,7 +98,7 @@ function! vista#sidebar#Close() abort
   endif
 
   if exists('t:vista.winnr')
-    let winnr = t:vista.winnr
+    let winnr = t:vista.winnr()
     noautocmd execute winnr.'wincmd w'
     if winnr() == winnr
       close!

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -81,6 +81,11 @@ function! vista#sidebar#OpenOrUpdate(rows) abort
 
   call vista#util#SetBufline(t:vista.bufnr, a:rows)
 
+  if has_key(t:vista, 'lnum')
+    call vista#cursor#ShowTagFor(t:vista.lnum)
+    unlet t:vista.lnum
+  endif
+
   if !get(g:, 'vista_stay_on_open', 1)
     wincmd p
   endif

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -33,7 +33,7 @@ function! vista#sidebar#Reload(data) abort
     return
   endif
 
-  let winnr = bufwinnr(t:vista.bufnr)
+  let winnr = t:vista.winnr()
 
   " Abort if can't find vista window
   if winnr == -1
@@ -64,7 +64,7 @@ function! vista#sidebar#OpenOrUpdate(rows) abort
     let t:vista.winid = win_getid()
     let t:vista.pos = [winsaveview(), winnr(), winrestcmd()]
   else
-    let winnr = bufwinnr(t:vista.bufnr)
+    let winnr = t:vista.winnr()
     if winnr ==  -1
       silent execute 'botright vsplit +buffer'.t:vista.bufnr
       vertical resize 30
@@ -107,7 +107,6 @@ function! vista#sidebar#Close() abort
       noautocmd execute pos[1].'wincmd w'
       call winrestview(pos[0])
     endif
-    unlet t:vista.winnr
   endif
 
   call s:ClearAugroups('VistaCoc', 'VistaCtags')

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -96,13 +96,6 @@ function! s:ClearAugroups(...) abort
   endfor
 endfunction
 
-function! vista#sidebar#CloseIfVisible() abort
-  let winnr = bufwinnr('__vista__')
-  if winnr != -1
-    execute winnr.'close!'
-  endif
-endfunction
-
 function! s:GetExplicitExecutive() abort
   let ft = &filetype
 

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -16,7 +16,7 @@ function! s:NewWindow() abort
 
   " FIXME when to delete?
   if has_key(t:vista.source, 'fpath')
-    let w:first_line_hi_id = matchaddpos('MoreMsg', [1])
+    let w:vista_first_line_hi_id = matchaddpos('MoreMsg', [1])
   endif
 endfunction
 

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -76,37 +76,13 @@ endfunction
 
 function! vista#sidebar#Close() abort
   if exists('t:vista.bufnr')
+    let winnr = t:vista.winnr()
+    if winnr != -1
+      noautocmd execute winnr.'wincmd c'
+    endif
+
     silent execute  t:vista.bufnr.'bwipe!'
     unlet t:vista.bufnr
-  endif
-
-  " let winnr = t:vista.winnr()
-
-  " " Abort if can't find vista window
-  " if winnr == -1
-    " return
-  " endif
-
-  " let switch_in = winnr() != winnr
-
-  " if switch_in
-    " noautocmd execute winnr."wincmd w"
-  " endif
-
-  " if switch_in
-    " wincmd p
-  " endif
-  "
-  if exists('t:vista.winnr')
-    let winnr = t:vista.winnr()
-    noautocmd execute winnr.'wincmd w'
-    if winnr() == winnr
-      close!
-      let pos = t:vista.pos
-      execute pos[-1]
-      noautocmd execute pos[1].'wincmd w'
-      call winrestview(pos[0])
-    endif
   endif
 
   call s:ClearAugroups('VistaCoc', 'VistaCtags')

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -7,6 +7,9 @@ let s:use_winid = exists('*bufwinid')
 function! s:EnsureExists() abort
   if !exists('t:vista')
     let t:vista = {}
+    function! t:vista.winnr() abort
+      return bufwinnr('__vista__')
+    endfunction
   endif
 
   if !has_key(t:vista, 'source')

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -2,22 +2,46 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-function! vista#source#Lines() abort
-  return getbufline(t:vista.source.bufnr, 1, '$')
-endfunction
+let s:use_winid = exists('*bufwinid')
 
-function! vista#source#Line(lnum) abort
-  let bufline = getbufline(t:vista.source.bufnr, a:lnum)
-  return empty(bufline) ? '' : vista#util#Trim(bufline[0])
-endfunction
+function! s:EnsureExists() abort
+  if !exists('t:vista')
+    let t:vista = {}
+  endif
 
-function! vista#source#Extension() abort
-  return fnamemodify(t:vista.source.fpath, ':e')
+  if !has_key(t:vista, 'source')
+    let t:vista.source = {}
+
+    function! t:vista.source.winnr() abort
+      return bufwinnr(self.bufnr)
+    endfunction
+
+    function! t:vista.source.winid() abort
+      return bufwinid(self.bufnr)
+    endfunction
+
+    function! t:vista.source.filetype() abort
+      return getbufvar(self.bufnr, '&filetype')
+    endfunction
+
+    function! t:vista.source.lines() abort
+      return getbufline(self.bufnr, 1, '$')
+    endfunction
+
+    function! t:vista.source.line(lnum) abort
+      let bufline = getbufline(self.bufnr, a:lnum)
+      return empty(bufline) ? '' : vista#util#Trim(bufline[0])
+    endfunction
+
+    function! t:vista.source.extension() abort
+      return fnamemodify(self.fpath, ':e')
+    endfunction
+  endif
 endfunction
 
 function! vista#source#GotoWin() abort
-  if exists('*bufwinid')
-    let winid = bufwinid(t:vista.source.bufnr)
+  if s:use_winid
+    let winid = t:vista.source.winid()
     if winid != -1
       call win_gotoid(winid)
     else
@@ -25,7 +49,7 @@ function! vista#source#GotoWin() abort
     endif
   else
     " t:vista.source.winnr is not always correct.
-    let winnr = bufwinnr(t:vista.source.bufnr)
+    let winnr = t:vista.source.winnr()
     if winnr != -1
       noautocmd execute winnr."wincmd w"
     else
@@ -41,12 +65,12 @@ endfunction
 " Update the infomation of source file to be processed,
 " including whose bufnr, winnr, fname, fpath
 function! vista#source#Update(bufnr, winnr, ...) abort
-  if !exists('t:vista')
-    let t:vista = {}
+  if !exists('t:_vista_initialized')
+    call s:EnsureExists()
+    let t:_vista_initialized = 1
   endif
-  let t:vista.source = get(t:vista, 'source', {})
+
   let t:vista.source.bufnr = a:bufnr
-  let t:vista.source.winnr = a:winnr
 
   if a:0 == 1
     let t:vista.source.fname = a:1

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -39,14 +39,16 @@ function! s:PrependFpath(lines) abort
 endfunction
 
 function! vista#util#SetBufline(bufnr, lines) abort
-  setlocal noreadonly modifiable
+  call setbufvar(a:bufnr, '&readonly', 0)
+  call setbufvar(a:bufnr, '&modifiable', 1)
   let lines = s:PrependFpath(a:lines)
   if has('nvim')
     call nvim_buf_set_lines(a:bufnr, 0, -1, 0, lines)
   else
     call setbufline(a:bufnr, 1, lines)
   endif
-  setlocal readonly nomodifiable
+  call setbufvar(a:bufnr, '&readonly', 1)
+  call setbufvar(a:bufnr, '&modifiable', 0)
 endfunction
 
 function! vista#util#JobStop(jobid) abort

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -57,6 +57,10 @@ function! vista#util#JobStop(jobid) abort
   endif
 endfunction
 
+function! vista#util#Join(...) abort
+  return join(a:000, '')
+endfunction
+
 " Blink current line under cursor, from junegunn/vim-slash
 function! vista#util#Blink(times, delay) abort
   let s:blink = { 'ticks': 2 * a:times, 'delay': a:delay }
@@ -128,9 +132,9 @@ function! vista#util#LowerIndentLineNr() abort
   return 0
 endfunction
 
-" array: List of Method or Function symbols
+" array: List of Dict, composed of Method or Function symbols
 " target: current line number in the source buffer
-function! vista#util#BinarySearch(array, target) abort
+function! vista#util#BinarySearch(array, target, cmp_key, ret_key) abort
   let [array, target] = [a:array, a:target]
 
   let low = 0
@@ -138,10 +142,10 @@ function! vista#util#BinarySearch(array, target) abort
 
   while low <= high
     let mid = (low + high) / 2
-    if array[mid].lnum == target
+    if array[mid][a:cmp_key] == target
       let found = array[mid]
-      return found.text
-    elseif array[mid].lnum > target
+      return found[a:ret_key]
+    elseif array[mid][a:cmp_key] > target
       let high = mid - 1
     else
       let low = mid + 1
@@ -154,7 +158,7 @@ function! vista#util#BinarySearch(array, target) abort
 
   " If no exact match, prefer the previous nearest one.
   if get(g:, 'vista_find_absolute_nearest_method_or_function', 0)
-    if abs(array[low].lnum - target) < abs(array[low - 1].lnum - target)
+    if abs(array[low][a:cmp_key] - target) < abs(array[low - 1][a:cmp_key] - target)
       let found = array[low]
     else
       let found = array[low - 1]
@@ -163,5 +167,5 @@ function! vista#util#BinarySearch(array, target) abort
     let found = array[low - 1]
   endif
 
-  return found.text
+  return found[a:ret_key]
 endfunction

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -103,6 +103,9 @@ Vista                                                                      *Vist
 
   `:Vista`: same with `:Vista ctags` .
 
+  `:Vista show`: jump to the tag nearby the current cursor in vista window.
+  This feature needs `let g:vista_ctags_renderer = 'default'` at the moment.
+
   `:Vista ctags`: open vista window based on ctags.
 
   `:Vista coc`: open vista window based on coc.nvim.

--- a/ftplugin/vista.vim
+++ b/ftplugin/vista.vim
@@ -31,7 +31,9 @@ setlocal foldmethod=expr
 setlocal foldexpr=vista#fold#Expr()
 setlocal foldtext=vista#fold#Text()
 
-let &l:statusline = vista#statusline()
+if !vista#statusline#ShouldDisable()
+  let &l:statusline = vista#statusline#()
+endif
 
 nnoremap <buffer> <silent> q    :close<CR>
 nnoremap <buffer> <silent> <CR> :<c-u>call vista#cursor#FoldOrJump()<CR>

--- a/ftplugin/vista.vim
+++ b/ftplugin/vista.vim
@@ -1,0 +1,49 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+" No usual did_ftplugin check here
+
+setlocal
+  \ nonumber
+  \ norelativenumber
+  \ nopaste
+  \ nomodeline
+  \ noswapfile
+  \ nocursorline
+  \ nocursorcolumn
+  \ colorcolumn=
+  \ nobuflisted
+  \ buftype=nofile
+  \ bufhidden=hide
+  \ nomodifiable
+  \ signcolumn=no
+  \ textwidth=0
+  \ nolist
+  \ winfixwidth
+  \ winfixheight
+  \ nospell
+  \ nofoldenable
+  \ foldcolumn=0
+  \ nowrap
+
+setlocal foldmethod=expr
+setlocal foldexpr=vista#fold#Expr()
+setlocal foldtext=vista#fold#Text()
+
+let &l:statusline = vista#statusline()
+
+nnoremap <buffer> <silent> q    :close<CR>
+nnoremap <buffer> <silent> <CR> :<c-u>call vista#cursor#FoldOrJump()<CR>
+nnoremap <buffer> <silent> /    :<c-u>call vista#finder#fzf#Run()<CR>
+
+augroup VistaCursor
+  autocmd!
+  if get(g:, 'vista_echo_cursor', 1)
+    autocmd CursorMoved <buffer> call vista#cursor#ShowDetailWithDelay()
+  endif
+augroup END
+
+if !exists('#VistaMOF')
+  call vista#autocmd#InitMOF()
+endif

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -1,0 +1,29 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+if exists('b:current_syntax')
+  finish
+endif
+
+syntax match VistaAccessPublic /^+/ contained
+syntax match VistaAccessProtected /^#/ contained
+syntax match VistaAccessPrivate /^-/ contained
+
+syntax match VistaColon /:/ contained
+syntax match VistaLineNr /:\d*$/ contains=VistaColon
+syntax match VistaKind / \a*:\d*$/ contains=VistaLineNr
+syntax match VistaScope /^\S.*$/ contains=VistaAccessPrivate,VistaAccessProtected,VistaAccessPublic,VistaKind
+syntax region VistaTag start="^" end="$" contains=VistaLineNr,VistaScope,VistaAccessPrivate,VistaAccessProtected,VistaAccessPublic
+
+hi default link VistaScope       Function
+hi default link VistaTag         Keyword
+hi default link VistaKind        Type
+hi default link VistaLineNr      LineNr
+hi default link VistaColon       SpecialKey
+
+hi default VistaAccessPublic     guifg=Green  ctermfg=Green
+hi default VistaAccessProtected  guifg=Yellow ctermfg=Yellow
+hi default VistaAccessPrivate    guifg=Red    ctermfg=Red
+
+let b:current_syntax = 'vista'


### PR DESCRIPTION
This PR is the first step of #30, still missint the nested feature for now. But some other features are usable(with bug apparently) via `:let g:vista_ctags_renderer = 'default' | Vista` :

- highlight the nearest tag in the vista window automatically.
- when the vista sidebar is open, `:Vista show` jumps to the location of current nearest tag.
- lots of refactoring stuff.
-  fixes #31, use `:let g:vista_ctags_renderer = 'default' | Vista show` for now.

I choose the leave the doc behind since it's still experimental, but testers are highly welcome.

I'll continue to work on the nested feature after merging this. 