### PR TITLE
Add markdown extension

### DIFF
--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -69,6 +69,8 @@ function! vista#(bang, ...) abort
       call vista#finder#fzf#Run('coc')
     elseif a:1 == 'finder!'
       call vista#finder#fzf#ProjectRun()
+    elseif a:1 == 'toc'
+      call vista#extension#markdown#Execute(v:false, v:true)
     elseif a:1 == 'show'
       if vista#sidebar#IsVisible()
         call vista#cursor#ShowTag()

--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -70,7 +70,12 @@ function! vista#(bang, ...) abort
     elseif a:1 == 'finder!'
       call vista#finder#fzf#ProjectRun()
     elseif a:1 == 'toc'
-      call vista#extension#markdown#Execute(v:false, v:true)
+      if &filetype == 'markdown'
+        call vista#source#Update(bufnr, winnr, fname, fpath)
+        call vista#extension#markdown#Execute(v:false, v:true)
+      else
+        return vista#error#For('Vista toc', 'markdown')
+      endif
     elseif a:1 == 'show'
       if vista#sidebar#IsVisible()
         call vista#cursor#ShowTag()

--- a/autoload/vista/error.vim
+++ b/autoload/vista/error.vim
@@ -2,9 +2,9 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-function! s:Echom(group, msg) abort
+function! s:Echo(group, msg) abort
   execute 'echohl' a:group
-  echom a:msg
+  echo a:msg
   echohl NONE
 endfunction
 
@@ -15,20 +15,20 @@ function! s:Echon(group, msg) abort
 endfunction
 
 function! vista#error#Expect(expected) abort
-  call s:Echom('ErrorMsg', '[vista.vim]')
+  call s:Echo('ErrorMsg', '[vista.vim]')
   call s:Echon('Normal', ' Invalid args. expected: ')
   call s:Echon('Underlined', a:expected)
 endfunction
 
 function! vista#error#Need(needed) abort
-  call s:Echom('ErrorMsg', '[vista.vim]')
+  call s:Echo('ErrorMsg', '[vista.vim]')
   call s:Echon('Normal', ' You must have ')
   call s:Echon('Underlined', a:needed)
   call s:Echon('Normal', ' installed to continue.')
 endfunction
 
 function! vista#error#InvalidExecutive(exe) abort
-  call s:Echom('ErrorMsg', '[vista.vim]')
+  call s:Echo('ErrorMsg', '[vista.vim]')
   call s:Echon('Normal', ' The executive')
   call s:Echon('Underlined', ' '.a:exe.' ')
   call s:Echon('Normal', 'does not exist. Avaliable: ')
@@ -36,7 +36,7 @@ function! vista#error#InvalidExecutive(exe) abort
 endfunction
 
 function! vista#error#RunCtags(cmd) abort
-  call s:Echom('ErrorMsg', '[vista.vim]')
+  call s:Echo('ErrorMsg', '[vista.vim]')
   call s:Echon('Normal', 'Fail to run ctags given the command: ')
   call s:Echon('Underlined', a:cmd)
 endfunction
@@ -45,12 +45,12 @@ function! vista#error#ParseError() abort
 endfunction
 
 function! vista#error#InvalidOption(opt, ...) abort
-  call s:Echom('ErrorMsg', '[vista.vim]')
+  call s:Echo('ErrorMsg', '[vista.vim]')
   call s:Echon('Normal', ' Invalid option '.a:opt.'. Avaliable: ')
   call s:Echon('Underlined', a:0 > 0 ? string(a:1) : '')
 endfunction
 
 function! vista#error#(msg) abort
-  call s:Echom('ErrorMsg', '[vista.vim]')
+  call s:Echo('ErrorMsg', '[vista.vim]')
   call s:Echon('Normal', a:msg)
 endfunction

--- a/autoload/vista/error.vim
+++ b/autoload/vista/error.vim
@@ -41,7 +41,10 @@ function! vista#error#RunCtags(cmd) abort
   call s:Echon('Underlined', a:cmd)
 endfunction
 
-function! vista#error#ParseError() abort
+function! vista#error#For(cmd, filetype) abort
+  call s:Echo('ErrorMsg', '[vista.vim]')
+  call s:Echon('Underlined', ' '.a:cmd)
+  call s:Echon('Normal', ' only exists in '.a:filetype.' filetype.')
 endfunction
 
 function! vista#error#InvalidOption(opt, ...) abort

--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -83,7 +83,9 @@ function! s:on_exit(_job, _data, _event) abort dict
 
   call s:ApplyExtracted()
 
-  unlet s:id
+  if exists('s:id')
+    unlet s:id
+  endif
 endfunction
 
 function! s:close_cb(channel)
@@ -96,7 +98,9 @@ function! s:close_cb(channel)
 
   call s:ApplyExtracted()
 
-  unlet s:id
+  if exists('s:id')
+    unlet s:id
+  endif
 endfunction
 
 function! s:ApplyExtracted() abort

--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -306,10 +306,10 @@ function! vista#executive#ctags#ProjectRun() abort
   " Otherwise we will use the `--_xformat` option.
   if s:support_json_format
     let cmd = s:ctags." -R -x --output-format=json --fields=+n"
-    let Parser = function('vista#parser#ctags#ProjectTagFromJSON')
+    let Parser = function('vista#parser#ctags#RecursiveFromJSON')
   else
     let cmd = s:ctags." -R -x --_xformat='TAGNAME:%N ++++ KIND:%K ++++ LINE:%n ++++ INPUT-FILE:%F ++++ PATTERN:%P'"
-    let Parser = function('vista#parser#ctags#ProjectTagFromXformat')
+    let Parser = function('vista#parser#ctags#RecursiveFromXformat')
   endif
 
   let output = system(cmd)

--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -119,8 +119,16 @@ function! s:ExtractLinewise(raw_data) abort
 endfunction
 
 function! s:AutoUpdate(fpath) abort
-  let s:reload_only = v:true
-  call s:ApplyExecute(v:false, a:fpath)
+  if t:vista.source.filetype() == 'markdown'
+    call vista#extension#markdown#AutoUpdate(a:fpath)
+  else
+    let s:reload_only = v:true
+    call s:ApplyExecute(v:false, a:fpath)
+  endif
+endfunction
+
+function! vista#executive#ctags#AutoUpdate(fpath) abort
+  call s:AutoUpdate(a:fpath)
 endfunction
 
 " Run ctags synchronously given the cmd

--- a/autoload/vista/executive/lcn.vim
+++ b/autoload/vista/executive/lcn.vim
@@ -19,7 +19,7 @@ function s:Handler(output) abort
   let result = a:output.result
 
   let lines = []
-  call map(result, 'vista#parser#lsp#FromKindToSymbol(v:val, lines)')
+  call map(result, 'vista#parser#lsp#KindToSymbol(v:val, lines)')
 
   let s:data = {}
   let t:vista.functions = []

--- a/autoload/vista/executive/vim_lsp.vim
+++ b/autoload/vista/executive/vim_lsp.vim
@@ -18,7 +18,7 @@ function! s:Handler(_server, _req_id, _type, data) abort
   let result = a:data.response.result
 
   let lines = []
-  call map(result, 'vista#parser#lsp#FromKindToSymbol(v:val, lines)')
+  call map(result, 'vista#parser#lsp#KindToSymbol(v:val, lines)')
 
   let s:data = {}
   let t:vista.functions = []

--- a/autoload/vista/extension/markdown.vim
+++ b/autoload/vista/extension/markdown.vim
@@ -61,11 +61,6 @@ endfunction
 
 " Credit: originally from `:Toc` of vim-markdown
 function! vista#extension#markdown#Execute(_bang, should_display) abort
-
-  let [bufnr, winnr, fname, fpath] = [bufnr('%'), winnr(), expand('%'), expand('%:p')]
-
-  call vista#source#Update(bufnr, winnr, fname, fpath)
-
   call vista#OnExecute(s:provider, function('s:AutoUpdate'))
 
   let headers =  s:Execute()

--- a/autoload/vista/extension/markdown.vim
+++ b/autoload/vista/extension/markdown.vim
@@ -1,0 +1,75 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+let s:provider = fnamemodify(expand('<sfile>'), ':t:r')
+
+function! s:IsHeader(cur_line, next_line) abort
+  return a:cur_line =~ '^#\+' ||
+        \ a:cur_line =~ '^\S' && (a:next_line =~ '^=\+\s*$' || a:next_line =~ '^-\+\s*$')
+endfunction
+
+function! s:Execute() abort
+  let is_fenced_block = 0
+
+  let headers = []
+
+  let idx = 0
+  let lines = t:vista.source.lines()
+
+  for line in lines
+    let line = substitute(line, "#", "\\\#", "g")
+    let next_line = get(lines, idx + 1, '')
+
+    if l:line =~ '````*' || l:line =~ '\~\~\~\~*'
+      let is_fenced_block = !is_fenced_block
+    endif
+
+    let is_header =s:IsHeader(l:line, l:next_line)
+
+    if is_header && !is_fenced_block
+        let item = {'lnum': idx+1, 'text': l:line}
+        let matched = matchlist(l:line, '\#*')
+        let item['level'] = len(matched[0])
+        call add(headers, l:item)
+    endif
+
+    let idx += 1
+  endfor
+
+  return headers
+endfunction
+
+function! s:ApplyAutoUpdate() abort
+  let rendered = vista#renderer#markdown#Render(s:Execute())
+  call vista#util#SetBufline(t:vista.bufnr, rendered)
+endfunction
+
+function! vista#extension#markdown#AutoUpdate(fpath)
+  call s:AutoUpdate(a:fpath)
+endfunction
+
+function! s:AutoUpdate(fpath) abort
+  if t:vista.source.filetype() == 'markdown'
+    call s:ApplyAutoUpdate()
+  else
+    call vista#executive#ctags#AutoUpdate(a:fpath)
+  endif
+endfunction
+
+" Credit: originally from `:Toc` of vim-markdown
+function! vista#extension#markdown#Execute(_bang, should_display) abort
+
+  let [bufnr, winnr, fname, fpath] = [bufnr('%'), winnr(), expand('%'), expand('%:p')]
+
+  call vista#source#Update(bufnr, winnr, fname, fpath)
+
+  call vista#OnExecute(s:provider, function('s:AutoUpdate'))
+
+  let headers =  s:Execute()
+
+  if a:should_display
+    let rendered = vista#renderer#markdown#Render(headers)
+    call vista#sidebar#OpenOrUpdate(rendered)
+  endif
+endfunction

--- a/autoload/vista/extension/markdown.vim
+++ b/autoload/vista/extension/markdown.vim
@@ -41,8 +41,10 @@ function! s:Execute() abort
 endfunction
 
 function! s:ApplyAutoUpdate() abort
-  let rendered = vista#renderer#markdown#Render(s:Execute())
-  call vista#util#SetBufline(t:vista.bufnr, rendered)
+  if has_key(t:vista, 'bufnr')
+    let rendered = vista#renderer#markdown#Render(s:Execute())
+    call vista#util#SetBufline(t:vista.bufnr, rendered)
+  endif
 endfunction
 
 function! vista#extension#markdown#AutoUpdate(fpath)

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -203,7 +203,6 @@ function! s:TryAlternatives(tried, fpath) abort
   let alternatives = filter(copy(executives), 'v:val != a:tried')
 
   for alternative in alternatives
-    " FIXME when running synchornously, no need to add extra check.
     let s:data = vista#executive#{alternative}#Run(a:fpath)
     if !empty(s:data)
       let s:cur_executive = alternative
@@ -215,6 +214,7 @@ function! s:TryAlternatives(tried, fpath) abort
   return v:false
 endfunction
 
+" TODO workspace symbols
 function! vista#finder#fzf#ProjectRun() abort
   let executive = 'ctags'
   let s:data = vista#executive#{executive}#ProjectRun()

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -21,26 +21,6 @@ endfunction
 "   'kind': 'Function',
 "   'text': 'testnet_genesis',
 " }
-"
-function! vista#parser#ctags#ExtractTag(line, container) abort
-  " {tagname}<Tab>{tagfile}<Tab>{tagaddress}[;"<Tab>{tagfield}..]
-  " {tagname}<Tab>{tagfile}<Tab>{tagaddress};"<Tab>{kind}<Tab>{scope}
-  " ['vista#executive#ctags#Execute', '/Users/xlc/.vim/plugged/vista.vim/autoload/vista/executive/ctags.vim', '84;"', 'function']
-  let items = split(a:line, '\t')
-
-  let tagname = items[0]
-  let tagfile = items[1]
-  let lnum = split(items[2], ';')[0]
-  let scope = items[-1]
-
-  let picked = {'lnum': lnum, 'text': tagname}
-
-  if scope =~# '^f'
-    call add(t:vista.functions, picked)
-  endif
-
-  call s:Insert(a:container, scope, picked)
-endfunction
 
 function! s:ShortToLong(short) abort
   let ft = getbufvar(t:vista.source.bufnr, '&filetype')
@@ -84,6 +64,9 @@ function! s:ParseTagfield(tagfields) abort
   return fields
 endfunction
 
+" {tagname}<Tab>{tagfile}<Tab>{tagaddress}[;"<Tab>{tagfield}..]
+" {tagname}<Tab>{tagfile}<Tab>{tagaddress};"<Tab>{kind}<Tab>{scope}
+" ['vista#executive#ctags#Execute', '/Users/xlc/.vim/plugged/vista.vim/autoload/vista/executive/ctags.vim', '84;"', 'function']
 function! vista#parser#ctags#FromExtendedRaw(line, container) abort
   if a:line =~ '^!_TAG'
     return
@@ -138,22 +121,9 @@ function! vista#parser#ctags#FromJSON(line, container) abort
   call s:Insert(a:container, kind, picked)
 endfunction
 
-function! vista#parser#ctags#TagFromJSON(line, container) abort
-  let line = json_decode(a:line)
-
-  let kind = line.kind
-
-  let picked = {'lnum': line.line, 'text': line.name }
-
-  if kind =~# '^f'
-    call add(t:vista.functions, picked)
-  endif
-
-  call s:Insert(a:container, kind, picked)
-endfunction
-
-function! vista#parser#ctags#ProjectTagFromXformat(line, container) abort
-  " let cmd = "ctags -R -x --_xformat='TAGNAME:%N ++++ KIND:%K ++++ LINE:%n ++++ INPUT-FILE:%F ++++ PATTERN:%P'"
+" ctags -R -x --_xformat='TAGNAME:%N ++++ KIND:%K ++++ LINE:%n ++++ INPUT-FILE:%F ++++ PATTERN:%P'"
+"
+function! vista#parser#ctags#RecursiveFromXformat(line, container) abort
 
   if a:line =~ '^ctags: Warning: ignoring null tag'
     return
@@ -184,7 +154,7 @@ function! vista#parser#ctags#ProjectTagFromXformat(line, container) abort
   call s:Insert(a:container, kind, picked)
 endfunction
 
-function! vista#parser#ctags#ProjectTagFromJSON(line, container) abort
+function! vista#parser#ctags#RecursiveFromJSON(line, container) abort
   " {
   "  "_type":"tag",
   "  "name":"vista#source#Update",
@@ -193,6 +163,10 @@ function! vista#parser#ctags#ProjectTagFromJSON(line, container) abort
   "  "line":29,
   "  "kind":"function"
   " }
+  if a:line =~ '^ctags: Warning: ignoring null tag'
+    return
+  endif
+
   let line = json_decode(a:line)
 
   let kind = line.kind

--- a/autoload/vista/parser/lsp.vim
+++ b/autoload/vista/parser/lsp.vim
@@ -43,7 +43,7 @@ endfunction
 
 " The kind field in the result is a number instead of a readable text, we
 " should transform the number to the symbol text first.
-function! vista#parser#lsp#FromKindToSymbol(line, container) abort
+function! vista#parser#lsp#KindToSymbol(line, container) abort
   let line = a:line
   let location = line.location
   if s:IsFileUri(location.uri)

--- a/autoload/vista/renderer/markdown.vim
+++ b/autoload/vista/renderer/markdown.vim
@@ -11,12 +11,12 @@ function! vista#renderer#markdown#Render(data) abort
     let text = vista#util#Trim(line['text'][level:])
     let lnum = line.lnum
     if level > 1
-      let row = repeat(' ', 4 * level).s:default_icon[0].' '.text.': h'.level.' :'.lnum
+      let row = repeat(' ', 4 * level).s:default_icon[0].' '.text.': H'.level.' :'.lnum
     else
       let row = text.':'.lnum
     endif
 
-    let row = repeat(' ', 2 * level).s:default_icon[0].text.':h'.level.' :'.lnum
+    let row = repeat(' ', 2 * level).s:default_icon[0].text.':H'.level.' :'.lnum
     call add(rows, row)
   endfor
 

--- a/autoload/vista/renderer/markdown.vim
+++ b/autoload/vista/renderer/markdown.vim
@@ -1,0 +1,24 @@
+let s:default_icon = ["╰─▸ ", "├─▸ "]
+
+function! vista#renderer#markdown#Render(data) abort
+  " {'lnum': 1, 'level': '4', 'text': '# Vista.vim'}
+  let data = a:data
+
+  let rows = []
+
+  for line in data
+    let level = line.level
+    let text = vista#util#Trim(line['text'][level:])
+    let lnum = line.lnum
+    if level > 1
+      let row = repeat(' ', 4 * level).s:default_icon[0].' '.text.': h'.level.' :'.lnum
+    else
+      let row = text.':'.lnum
+    endif
+
+    let row = repeat(' ', 2 * level).s:default_icon[0].text.':h'.level.' :'.lnum
+    call add(rows, row)
+  endfor
+
+  return rows
+endfunction

--- a/autoload/vista/renderer/markdown.vim
+++ b/autoload/vista/renderer/markdown.vim
@@ -11,12 +11,12 @@ function! vista#renderer#markdown#Render(data) abort
     let text = vista#util#Trim(line['text'][level:])
     let lnum = line.lnum
     if level > 1
-      let row = repeat(' ', 4 * level).s:default_icon[0].' '.text.': H'.level.' :'.lnum
+      let row = repeat(' ', 4 * level).s:default_icon[0].' '.text.' H'.level.':'.lnum
     else
       let row = text.':'.lnum
     endif
 
-    let row = repeat(' ', 2 * level).s:default_icon[0].text.':H'.level.' :'.lnum
+    let row = repeat(' ', 2 * level).s:default_icon[0].text.' H'.level.':'.lnum
     call add(rows, row)
   endfor
 

--- a/autoload/vista/types/uctags/python.vim
+++ b/autoload/vista/types/uctags/python.vim
@@ -5,11 +5,11 @@ let s:types = {}
 let s:types.lang = 'python'
 
 let s:types.kinds     = {
-    \ {'short' : 'i', 'long' : 'modules',   'fold' : 1, 'stl' : 0},
-    \ {'short' : 'c', 'long' : 'classes',   'fold' : 0, 'stl' : 1},
-    \ {'short' : 'f', 'long' : 'functions', 'fold' : 0, 'stl' : 1},
-    \ {'short' : 'm', 'long' : 'members',   'fold' : 0, 'stl' : 1},
-    \ {'short' : 'v', 'long' : 'variables', 'fold' : 0, 'stl' : 0}
+    \ 'i': {'long' : 'modules',   'fold' : 1, 'stl' : 0},
+    \ 'c': {'long' : 'classes',   'fold' : 0, 'stl' : 1},
+    \ 'f': {'long' : 'functions', 'fold' : 0, 'stl' : 1},
+    \ 'm': {'long' : 'members',   'fold' : 0, 'stl' : 1},
+    \ 'v': {'long' : 'variables', 'fold' : 0, 'stl' : 0}
     \ }
 
 let s:types.sro        = '.'

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -30,12 +30,12 @@ it seemingly doesn't have a plan to support the promising {Language Server Proto
 and async processing.
 
 In terms of viewer for ctags-generated tags, vista.vim is sort of the poor version
-of tagbar, for some details has not been worked out. Nonetheless, it's more than a
-tags viewer.
+of tagbar, for some details has not been worked out. Nonetheless, it's more than
+a tags viewer.
 
-Vista.vim can also be a symbol navigator similar to {ctrlp-funky}{4}. Last but not
-least, one important goal of vista.vim is to support LSP symbols, which understands
-the semantics instead of the regex only.
+Vista.vim can also be a symbol navigator similar to {ctrlp-funky}{4}. Last but
+not least, one important goal of vista.vim is to support LSP symbols, which
+understands the semantics instead of the regex only.
 
 {1} https://github.com/liuchengxu/vista.vim
 
@@ -48,31 +48,32 @@ the semantics instead of the regex only.
 --------------------------------------------------------------------------------
 FEATURES                                                          *vista-features*
 
-*   [x] View tags and LSP symbols in a sidebar.
-    *   [x] ctags (https://github.com/universal-ctags/ctags)
-    *   [x] vim-lsp (https://github.com/prabirshrestha/vim-lsp)
-    *   [x] coc.nvim (https://github.com/neoclide/coc.nvim)
-    *   [x] LanguageClient-neovim (https://github.com/autozimu/LanguageClient-neovim)
-*   [x] Finder for tags and LSP symbols.
-    *   [x] fzf (https://github.com/junegunn/fzf)
-*   [x] Display decent detailed symbol info in cmdline.
-*   [x] Jump to the tag/symbol from vista sidebar with a blink.
-*   [x] Update automatically when switching between buffers.
-*   [x] Update asynchonously in the background when `+job` avaliable.
-*   [x] Find the nearest method or function to the cursor, which could be
+[x] View tags and LSP symbols in a sidebar.
+    [x] ctags (https://github.com/universal-ctags/ctags)
+    [x] vim-lsp (https://github.com/prabirshrestha/vim-lsp)
+    [x] coc.nvim (https://github.com/neoclide/coc.nvim)
+    [x] LanguageClient-neovim (https://github.com/autozimu/LanguageClient-neovim)
+[x] Finder for tags and LSP symbols.
+    [x] fzf (https://github.com/junegunn/fzf)
+[x] Display decent detailed symbol info in cmdline.
+[x] Jump to the tag/symbol from vista sidebar with a blink.
+[x] Update automatically when switching between buffers.
+[x] Update asynchonously in the background when `+job` avaliable.
+[x] Find the nearest method or function to the cursor, which could be
     integrated into the statusline.
-*   [ ] Supports all of the languages that ctags does.
-*   [ ] Highlight current tag/symbol.
-*   [ ] Show the visibility (public/private) of tags.
-*   [ ] Tree viewer for hierarchy data.
+[ ] Supports all of the languages that ctags does.
+[ ] Highlight current tag/symbol.
+[ ] Show the visibility (public/private) of tags.
+[ ] Tree viewer for hierarchy data.
 
 Notes:
 
 *   The feature of finder in vista.vim is a bit like `:BTags` or `:Tags` in {fzf.vim}{5},
-`:CocList` in coc.nvim, `:LeaderfBufTag` in {leaderf.vim}{6}, etc. You can choose
-whichever you like.
+    `:CocList` in coc.nvim, `:LeaderfBufTag` in {leaderf.vim}{6}, etc. You can choose
+    whichever you like.
+
 *   I personally don't use all the features I have listed. Hence some of them
-may be on the TODOs forever :(.
+    may be on the TODOs forever :(.
 
 {5} https://github.com/junegunn/fzf.vim
 {6} https://github.com/Yggdroot/LeaderF
@@ -103,21 +104,34 @@ Vista                                                                      *Vist
 
   `:Vista`: same with `:Vista ctags` .
 
-  `:Vista show`: jump to the tag nearby the current cursor in vista window.
-  This feature needs `let g:vista_ctags_renderer = 'default'` at the moment.
+  `:Vista show`:  jump to the tag nearby the current cursor in vista window. This
+                feature needs `let g:vista_ctags_renderer = 'default'` at the moment.
 
-  `:Vista ctags`: open vista window based on ctags.
+  `:Vista toc`:   show table of contents of the markdown file.
 
-  `:Vista coc`: open vista window based on coc.nvim.
+                                                                 *vista-executive*
 
-  `:Vista finder`: same with `:Vista finder ctags` .
+  `:Vista coc`:     open vista window based on coc.nvim.
+
+  `:Vista lcn`:     open vista window based on LanguageClient-neovim.
+
+  `:Vista ctags`:   open vista window based on ctags.
+
+  `:Vista vim_lsp`: open vista window based on vim-lsp.
+
+                                                                    *vista-finder*
+
+  `:Vista finder`:  same with `:Vista finder ctags` .
 
   `:Vista finder!`: search tags recursively. Note: it's still experimental.
-  What's more, it may be very slow to generate all tags in a whole project.
+                  What's more, it may be very slow to generate all tags
+                  in a whole project.
 
-  `:Vista finder ctags`: search tags provided by ctags.
+  You can also specify an executive for the finder, for example:
 
   `:Vista finder coc`: search symbols provided by coc.nvim.
+
+  `:Vista finder ctags`: search tags provided by ctags.
 
 Vista!                                                                    *Vista!*
 
@@ -158,7 +172,7 @@ g:vista_cursor_delay                                        *g:vista_cursor_dela
 
   Time delay for showing detailed symbol info at current cursor.
 
-g:vista_echo_cursor_strategy                         *g:vista_echo_cursor_strategy*
+g:vista_echo_cursor_strategy                        *g:vista_echo_cursor_strategy*
 
   Type: |String|
   Default: `echo`
@@ -229,7 +243,7 @@ g:vista_executive_for                                      *g:vista_executive_fo
       \ 'php': 'vim_lsp',
       \ }
 
-g:vista_{&filetype}_executive                       *g:vista_{&filetype}_executive*
+g:vista_{&filetype}_executive                      *g:vista_{&filetype}_executive*
 
   Type: |String|
   Default: `''`
@@ -274,7 +288,7 @@ g:vista_fzf_opt                                                  *g:vista_fzf_op
 
   Append options to `fzf#run()`.
 
-g:vista_finder_alternative_executives       *g:vista_finder_alternative_executives*
+g:vista_finder_alternative_executives      *g:vista_finder_alternative_executives*
 
   Type: |List|
   Default: `['coc']`
@@ -283,7 +297,7 @@ g:vista_finder_alternative_executives       *g:vista_finder_alternative_executiv
   This is useful if you want to switch to `ctags` when LSP is not usable.
   By default it's all the provided executives excluding the tried one.
 
-g:vista_disable_statusline                              *g:vista_disable_statusline*
+g:vista_disable_statusline                            *g:vista_disable_statusline*
 
   Type: |Number|
   Default: `exists('g:loaded_airline') || exists('g:loaded_lightline')`


### PR DESCRIPTION
Closes #19.

The future work:

- [ ] refine the highlight of toc, link them to `markdownH[1-6]` respectively.
- [ ] speed up the parser, could be:
   - searching the header regex instead of iterating the whole buffer? refer to vim-markdown-toc. Still not sure if it's better.
   - an async external parser
        - https://github.com/jonschlinkert/markdown-toc
        - https://github.com/pbzweihander/markdown-toc