### PR TITLE
Fix syntax loading and refactoring

### DIFF
--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -379,8 +379,8 @@ function! vista#cursor#ShowDetail(_timer) abort
     " Join the scope parts in case of they contains spaces, e.g., structure names
     let scope = join(splitted[1:-2], ' ')
     let cnt = matchstr(splitted[-1], '\d\+')
-    echohl Keyword  | echo '['.scope.']: ' | echohl NONE
-    echohl Function | echon cnt            | echohl NONE
+    call s:EchoScope(scope)
+    echohl Keyword | echon cnt | echohl NONE
     return
   endif
 

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -46,7 +46,7 @@ function! s:GetInfoUnderCursor() abort
 
   " For scoped tag
   if has_key(t:vista, 'vlnum_cache')
-    let tagline = get(t:vista.vlnum_cache, line('.') - 3, '')
+    let tagline = t:vista.get_tagline_under_cursor()
     if !empty(tagline)
       return [tagline.name, source_line]
     endif

--- a/autoload/vista/executive/coc.vim
+++ b/autoload/vista/executive/coc.vim
@@ -11,6 +11,9 @@ function! s:PrepareContainer() abort
   let s:data = {}
   let t:vista.functions = []
   let t:vista.raw = []
+  let t:vista.without_containerName = []
+  let t:vista.with_containerName = []
+  let t:vista.containerName_map = {}
 endfunction
 
 " Extract fruitful infomation from raw symbols
@@ -91,6 +94,7 @@ function! s:Dispatch(F, ...) abort
     return
   endif
 
+  call vista#SetProvider(s:provider)
   return call(function(a:F), a:000)
 endfunction
 
@@ -103,6 +107,7 @@ endfunction
 " Run and RunAsync is for internal use.
 function! vista#executive#coc#Run(_fpath) abort
   if exists('*CocAction')
+    call vista#SetProvider(s:provider)
     call vista#util#EnsureRunOnSourceFile(function('s:Run'))
     return s:data
   endif

--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -282,6 +282,7 @@ function! s:Dispatch(F, ...) abort
     return
   endif
 
+  call vista#SetProvider(s:provider)
   return call(function(a:F), a:000)
 endfunction
 

--- a/autoload/vista/executive/lcn.vim
+++ b/autoload/vista/executive/lcn.vim
@@ -58,6 +58,7 @@ endfunction
 
 function! s:RunAsync() abort
   if exists('*LanguageClient#textDocument_documentSymbol')
+    call vista#SetProvider(s:provider)
     call vista#util#EnsureRunOnSourceFile(
           \ function('LanguageClient#textDocument_documentSymbol'),
           \ {'handle': v:false},

--- a/autoload/vista/executive/vim_lsp.vim
+++ b/autoload/vista/executive/vim_lsp.vim
@@ -66,6 +66,7 @@ function! s:Run() abort
 endfunction
 
 function! s:RunAsync() abort
+  call vista#SetProvider(s:provider)
   for server in s:servers
     call lsp#send_request(server, {
         \ 'method': 'textDocument/documentSymbol',

--- a/autoload/vista/extension/markdown.vim
+++ b/autoload/vista/extension/markdown.vim
@@ -42,6 +42,7 @@ endfunction
 
 function! s:ApplyAutoUpdate() abort
   if has_key(t:vista, 'bufnr') && t:vista.winnr() != -1
+    call vista#SetProvider(s:provider)
     let rendered = vista#renderer#markdown#Render(s:Execute())
     call vista#util#SetBufline(t:vista.bufnr, rendered)
   endif

--- a/autoload/vista/renderer/default.vim
+++ b/autoload/vista/renderer/default.vim
@@ -10,6 +10,8 @@ let s:visibility_icon = {
       \ 'private': '-',
       \ }
 
+let g:vista#renderer#default#vlnum_offset = 3
+
 " Return the rendered row to be displayed given the depth
 function! s:Assemble(line, depth) abort
   let line = a:line
@@ -182,7 +184,7 @@ function! s:GetVisibility(line) abort
   return has_key(a:line, 'access') ? get(s:visibility_icon, a:line.access, '?') : ''
 endfunction
 
-function! s:Compare(i1, i2) abort
+function! s:SortCompare(i1, i2) abort
   return a:i1.name > a:i2.name
 endfunction
 
@@ -196,7 +198,7 @@ function! s:RenderScopeless(scope_less, rows) abort
     let lines = scope_less[kind]
 
     if get(t:vista, 'sort', v:false)
-      let lines = sort(copy(lines), function('s:Compare'))
+      let lines = sort(copy(lines), function('s:SortCompare'))
     endif
 
     for line in lines
@@ -230,6 +232,9 @@ function! s:Render() abort
   " is related to the line in the vista sidebar, for we have to
   " remove the duplicate parents which leads to reassign the lnum
   " to the original tagline.
+  "
+  " The item of s:vlnum_cache is some original tagline dict with
+  " `vlnum` field added later.
   let s:vlnum_cache = []
 
   let scope_less = {}
@@ -260,12 +265,13 @@ function! s:Render() abort
 
   call s:RenderScopeless(scope_less, rows)
 
+  " The original tagline is positioned in which line in the vista sidebar.
   let idx = 0
   while idx < len(s:vlnum_cache)
     if !empty(s:vlnum_cache[idx])
       " idx is 0-based, while the line number is 1-based, and we prepend the
-      " two lines first.
-      let s:vlnum_cache[idx].vlnum = idx + 1 + 2
+      " two lines first, so the final offset is 1+2=3
+      let s:vlnum_cache[idx].vlnum = idx + g:vista#renderer#default#vlnum_offset
     endif
     let idx += 1
   endwhile

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -19,7 +19,7 @@ function! s:EnsureExists() abort
     " Get original tagline given the lnum in vista sidebar
     "
     " Mind the offset
-    function! t:vista.get_tagline_under_cursor()
+    function! t:vista.get_tagline_under_cursor() abort
       return get(t:vista.vlnum_cache, line('.') - g:vista#renderer#default#vlnum_offset, '')
     endfunction
 

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -7,12 +7,22 @@ let s:use_winid = exists('*bufwinid')
 function! s:EnsureExists() abort
   if !exists('t:vista')
     let t:vista = {}
+
     function! t:vista.winnr() abort
       return bufwinnr('__vista__')
     endfunction
+
     function! t:vista.winid() abort
       return bufwinid('__vista__')
     endfunction
+
+    " Get original tagline given the lnum in vista sidebar
+    "
+    " Mind the offset
+    function! t:vista.get_tagline_under_cursor()
+      return get(t:vista.vlnum_cache, line('.') - g:vista#renderer#default#vlnum_offset, '')
+    endfunction
+
   endif
 
   if !has_key(t:vista, 'source')

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -73,6 +73,8 @@ function! vista#util#SetBufline(bufnr, lines) abort
 
   if t:vista.provider ==# 'ctags' && g:vista#renderer#ctags ==# 'default'
     runtime! syntax/vista.vim
+  elseif t:vista.provider ==# 'markdown'
+    runtime! syntax/vista_markdown.vim
   else
     runtime! syntax/vista_kind.vim
   endif

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -71,6 +71,12 @@ function! vista#util#SetBufline(bufnr, lines) abort
   call setbufvar(a:bufnr, '&readonly', 1)
   call setbufvar(a:bufnr, '&modifiable', 0)
 
+  if t:vista.provider ==# 'ctags' && g:vista#renderer#ctags ==# 'default'
+    runtime! syntax/vista.vim
+  else
+    runtime! syntax/vista_kind.vim
+  endif
+
   if exists('l:switch_back')
     noautocmd wincmd p
   endif

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -2,7 +2,7 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-if exists('b:current_syntax')
+if exists('b:current_syntax') && b:current_syntax ==# 'vista'
   finish
 endif
 

--- a/syntax/vista_kind.vim
+++ b/syntax/vista_kind.vim
@@ -2,7 +2,7 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-if exists('b:current_syntax')
+if exists('b:current_syntax') && b:current_syntax ==# 'vista_kind'
   finish
 endif
 

--- a/syntax/vista_markdown.vim
+++ b/syntax/vista_markdown.vim
@@ -1,0 +1,29 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+if exists('b:current_syntax') && b:current_syntax ==# 'vista_markdown'
+  finish
+endif
+
+syntax match VistaColon /:/ contained
+syntax match VistaLineNr /\d\+$/
+
+syntax match VistaH1 /.*H1/ contains=VistaColon,VistaLineNr
+syntax match VistaH2 /.*H2/ contains=VistaColon,VistaLineNr
+syntax match VistaH3 /.*H3/ contains=VistaColon,VistaLineNr
+syntax match VistaH4 /.*H4/ contains=VistaColon,VistaLineNr
+syntax match VistaH5 /.*H5/ contains=VistaColon,VistaLineNr
+syntax match VistaH6 /.*H6/ contains=VistaColon,VistaLineNr
+
+hi default link VistaColon       SpecialKey
+hi default link VistaLineNr      LineNr
+
+highlight default link VistaH1 markdownH1
+highlight default link VistaH2 markdownH2
+highlight default link VistaH3 markdownH3
+highlight default link VistaH4 markdownH4
+highlight default link VistaH5 markdownH5
+highlight default link VistaH6 markdownH6
+
+let b:current_syntax = 'vista_markdown'

--- a/syntax/vista_markdown.vim
+++ b/syntax/vista_markdown.vim
@@ -9,15 +9,18 @@ endif
 syntax match VistaColon /:/ contained
 syntax match VistaLineNr /\d\+$/
 
-syntax match VistaH1 /.*H1/ contains=VistaColon,VistaLineNr
-syntax match VistaH2 /.*H2/ contains=VistaColon,VistaLineNr
-syntax match VistaH3 /.*H3/ contains=VistaColon,VistaLineNr
-syntax match VistaH4 /.*H4/ contains=VistaColon,VistaLineNr
-syntax match VistaH5 /.*H5/ contains=VistaColon,VistaLineNr
-syntax match VistaH6 /.*H6/ contains=VistaColon,VistaLineNr
+syntax match VistaHeadNr /H1\|H2\|H3\|H4\|H5\|H6:\d\+$/ contains=VistaLineNr contained
+
+syntax match VistaH1 /.*H1/ contains=VistaColon,VistaLineNr,VistaHeadNr
+syntax match VistaH2 /.*H2/ contains=VistaColon,VistaLineNr,VistaHeadNr
+syntax match VistaH3 /.*H3/ contains=VistaColon,VistaLineNr,VistaHeadNr
+syntax match VistaH4 /.*H4/ contains=VistaColon,VistaLineNr,VistaHeadNr
+syntax match VistaH5 /.*H5/ contains=VistaColon,VistaLineNr,VistaHeadNr
+syntax match VistaH6 /.*H6/ contains=VistaColon,VistaLineNr,VistaHeadNr
 
 hi default link VistaColon       SpecialKey
 hi default link VistaLineNr      LineNr
+hi default link VistaHeadNr      Comment
 
 highlight default link VistaH1 markdownH1
 highlight default link VistaH2 markdownH2


### PR DESCRIPTION
- fix syntax mismatch when switching between the executives, e.g., `:Vista coc` and then `Vista ctags`.
- add vista_markdown syntax.

<img width="369" alt="屏幕快照 2019-05-10 下午10 38 31" src="https://user-images.githubusercontent.com/8850248/57535226-60444c00-7374-11e9-8a67-8e7be0469436.png">

