### PR TITLE
Remove some redundant errors when executive not available

### DIFF
--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -72,6 +72,10 @@ endfunction
 
 " Main entrance to interact with vista.vim
 function! vista#(bang, ...) abort
+  if exists('t:vista')
+    let t:vista.update_trigger = 'Command'
+  endif
+
   if a:bang
     if a:0 == 0
       call vista#sidebar#Close()

--- a/autoload/vista/autocmd.vim
+++ b/autoload/vista/autocmd.vim
@@ -12,7 +12,7 @@ function! s:ClearOtherEvents(group) abort
   endfor
 endfunction
 
-function! s:GenericAutoUpdate(fpath) abort
+function! s:GenericAutoUpdate(fpath, trigger) abort
   if vista#ShouldSkip()
     return
   endif
@@ -21,6 +21,7 @@ function! s:GenericAutoUpdate(fpath) abort
 
   call vista#source#Update(bufnr, winnr, fname, a:fpath)
 
+  let t:vista.update_trigger = a:trigger
   call s:ApplyAutoUpdate(a:fpath)
 endfunction
 
@@ -57,8 +58,12 @@ function! vista#autocmd#Init(group_name, AUF) abort
     "
     " CursorHold and CursorHoldI event have been removed in order to
     " highlight the nearest tag automatically.
-    autocmd BufEnter,BufWritePost,BufReadPost, *
-          \ call s:GenericAutoUpdate(fnamemodify(expand('<afile>'), ':p'))
+    autocmd BufEnter,BufReadPost, *
+          \ call s:GenericAutoUpdate(
+                \ fnamemodify(expand('<afile>'), ':p'), 'BufEnterOrRead')
+    autocmd BufWritePost, *
+          \ call s:GenericAutoUpdate(
+                \ fnamemodify(expand('<afile>'), ':p'), 'BufWrite')
   augroup END
 endfunction
 

--- a/autoload/vista/error.vim
+++ b/autoload/vista/error.vim
@@ -56,11 +56,11 @@ endfunction
 " Notify the error message when required.
 function! vista#error#Notify(msg) abort
   if vista#sidebar#IsVisible()
-    if get(t:vista, 'update_trigger', 'Command') != 'BufWrite'
+    if get(t:vista, 'update_trigger', 'Command') !=# 'BufWrite'
       call vista#error#(a:msg)
     endif
   else
-    if get(t:vista, 'update_trigger', 'Command') == 'Command'
+    if get(t:vista, 'update_trigger', 'Command') ==# 'Command'
       call vista#error#(a:msg)
     endif
   endif

--- a/autoload/vista/error.vim
+++ b/autoload/vista/error.vim
@@ -55,9 +55,14 @@ endfunction
 
 " Notify the error message when required.
 function! vista#error#Notify(msg) abort
-  if !get(t:vista, 'silent', v:true)
-    call vista#error#(a:msg)
-    let t:vista.silent = v:true
+  if vista#sidebar#IsVisible()
+    if get(t:vista, 'update_trigger', 'Command') != 'BufWrite'
+      call vista#error#(a:msg)
+    endif
+  else
+    if get(t:vista, 'update_trigger', 'Command') == 'Command'
+      call vista#error#(a:msg)
+    endif
   endif
 endfunction
 

--- a/autoload/vista/executive/coc.vim
+++ b/autoload/vista/executive/coc.vim
@@ -121,6 +121,5 @@ endfunction
 " outside, where sets the provider and auto update events.
 function! vista#executive#coc#Execute(bang, should_display, ...) abort
   call vista#OnExecute(s:provider, function('s:AutoUpdate'))
-  let t:vista.silent = v:false
   return s:Dispatch('s:Execute', a:bang, a:should_display)
 endfunction

--- a/autoload/vista/executive/lcn.vim
+++ b/autoload/vista/executive/lcn.vim
@@ -78,7 +78,6 @@ endfunction
 function! vista#executive#lcn#Execute(bang, should_display, ...) abort
   call vista#OnExecute(s:provider, function('s:AutoUpdate'))
 
-  let t:vista.silent = v:false
   let s:should_display = a:should_display
   if a:bang
     return s:Run()


### PR DESCRIPTION
When entering a buffer for which there isn't any executive available, only echo an error if the Vista window is visible. If the Vista window is not visible, only echo an error when invoking a Vista command inside that buffer. Never echo an error when writing the buffer.

In other words,
- is the Vista window visible?
  * if the buffer is written (`BufWritePost`), do not show error
  * else (Vista command invoked **OR** `BufEnter` **OR** `BufReadPost`), show error
- is the Vista window closed?
  * if a Vista command is invoked, show error
  * else (`BufWritePost` **OR** `BufEnter` **OR** `BufReadPost`), do not show error

Addresses #103.