### PR TITLE
Make fzf finder work with devicons

### DIFF
--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -160,7 +160,7 @@ function! s:Run(...) abort
 
   if exists('g:vista_fzf_preview')
     let preview_opts = call('fzf#vim#with_preview', g:vista_fzf_preview).options
-    let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . ':{}'
+    let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . (g:vista#renderer#enable_icon ? ':{2}' : ':{1}')
     call extend(opts.options, preview_opts)
   endif
 


### PR DESCRIPTION
Enabling devicons breaks fzf finder preview. This happens due to icons being injected into the preview command ahead of line number, breaking fzf.vim preview script.

This PR adds a simplistic change, utilizing field index to instead inject only a line number, which resides in the first field if devicons are not enabled and in the second one is they are.