### PR TITLE
Add skim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In addition to being a tags viewer, vista.vim can also be a symbol navigator sim
     - [x] [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
 - [x] Finder for tags and LSP symbols.
     - [x] [fzf](https://github.com/junegunn/fzf)
+    - [x] [skim](https://github.com/lotabout/skim)
 - [x] Nested display for ctags, list display for LSP symbols.
 - [x] Highlight the nearby tag in the vista sidebar.
 - [x] Builtin support for displaying markdown's TOC.

--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -136,7 +136,7 @@ function! vista#finder#PrepareOpts(source, prompt) abort
 endfunction
 
 " Actually call fzf#run() with a highlighter given the opts
-function! vista#finder#RunFZFOrSkim(apply_run, hi_fn) abort
+function! vista#finder#RunFZFOrSkim(apply_run) abort
   echo "\r"
 
   call a:apply_run()
@@ -144,7 +144,7 @@ function! vista#finder#RunFZFOrSkim(apply_run, hi_fn) abort
   " Only add highlights when using nvim, since vim has an issue with the highlight.
   " Ref #139
   if has('nvim')
-    call call(function(a:hi_fn), [])
+    call vista#finder#fzf#Highlight()
 
     " https://unix.stackexchange.com/questions/149209/refresh-changed-content-of-file-opened-in-vim
     " Vim Highlight does not work at times

--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -72,3 +72,92 @@ function! vista#finder#GetSymbols(...) abort
 
   return [s:data, s:cur_executive, s:using_alternative]
 endfunction
+
+" Find the maximum length of each column of items to be displayed
+function! s:FindColumnsMaxLen(raw_items) abort
+  let [max_len_kind, max_len_lnum_and_text] = [-1, -1]
+
+  for [kind, v] in items(a:raw_items)
+    let kind_len = strwidth(kind)
+    if kind_len > max_len_kind
+      let max_len_kind = kind_len
+    endif
+
+    for item in v
+      let lnum_and_text = printf('%s:%s', item.lnum, item.text)
+      let len_lnum_and_text = strwidth(lnum_and_text)
+      if len_lnum_and_text > max_len_lnum_and_text
+        let max_len_lnum_and_text = len_lnum_and_text
+      endif
+    endfor
+  endfor
+
+  return [max_len_kind, max_len_lnum_and_text]
+endfunction
+
+" Prepare source for fzf, skim finder
+function! vista#finder#PrepareSource(raw_items) abort
+  let source = []
+
+  let [max_len_kind, max_len_lnum_and_text] = s:FindColumnsMaxLen(a:raw_items)
+
+  for [kind, v] in items(a:raw_items)
+    let icon = vista#renderer#IconFor(kind)
+    for item in v
+      let line = t:vista.source.line_trimmed(item.lnum)
+      let lnum_and_text = printf('%s:%s', item.lnum, item.text)
+      let row = printf('%s %s%s  [%s]%s  %s',
+            \ icon,
+            \ lnum_and_text, repeat(' ', max_len_lnum_and_text- strwidth(lnum_and_text)),
+            \ kind, repeat(' ', max_len_kind - strwidth(kind)),
+            \ line)
+      call add(source, row)
+    endfor
+  endfor
+
+  return source
+endfunction
+
+" Prepare opts for fzf#run(fzf#wrap(opts))
+function! vista#finder#PrepareOpts(source, prompt) abort
+  let opts = {
+          \ 'source': a:source,
+          \ 'sink': function('vista#finder#fzf#sink'),
+          \ 'options': ['--prompt', a:prompt] + get(g:, 'vista_fzf_opt', []),
+          \ }
+
+  if exists('g:vista_fzf_preview')
+    let preview_opts = call('fzf#vim#with_preview', g:vista_fzf_preview).options
+    let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . (g:vista#renderer#enable_icon ? ':{2}' : ':{1}')
+    call extend(opts.options, preview_opts)
+  endif
+
+  return opts
+endfunction
+
+" Actually call fzf#run() with a highlighter given the opts
+function! vista#finder#RunFZFOrSkim(apply_run, hi_fn) abort
+  echo "\r"
+
+  call a:apply_run()
+
+  " Only add highlights when using nvim, since vim has an issue with the highlight.
+  " Ref #139
+  if has('nvim')
+    call call(function(a:hi_fn), [])
+
+    " https://unix.stackexchange.com/questions/149209/refresh-changed-content-of-file-opened-in-vim
+    " Vim Highlight does not work at times
+    "
+    "  &modifiable is to avoid error in MacVim - E948: Job still running (add ! to end the job)
+    " if !has('nvim') && &modifiable
+      " edit
+    " endif
+  endif
+endfunction
+
+function! vista#finder#Dispatch(finder, executive) abort
+  let finder = empty(a:finder) ? 'fzf' : a:finder
+  let executive = empty(a:executive) ? 'ctags' : a:executive
+  call vista#finder#{finder}#Run(executive)
+endfunction

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -170,8 +170,7 @@ endfunction
 " Ctags is the default.
 function! vista#finder#fzf#Run(...) abort
   if !exists('*fzf#run')
-    call vista#error#Need('fzf')
-    return
+    return vista#error#Need('https://github.com/junegunn/fzf')
   endif
 
   let [s:data, s:cur_executive, s:using_alternative] = call('vista#finder#GetSymbols', a:000)

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -96,7 +96,7 @@ function! s:Run(...) abort
 
   let s:opts = vista#finder#PrepareOpts(source, prompt)
 
-  call vista#finder#RunFZFOrSkim(function('s:ApplyRun'), 'vista#finder#fzf#Highlight')
+  call vista#finder#RunFZFOrSkim(function('s:ApplyRun'))
 endfunction
 
 function! s:project_sink(line) abort

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -4,6 +4,8 @@
 
 scriptencoding utf-8
 
+let s:finder = fnamemodify(expand('<sfile>'), ':t:r')
+
 let s:cols_layout = {}
 let s:aligner = {}
 
@@ -92,7 +94,8 @@ endfunction
 
 function! s:Run(...) abort
   let source  = vista#finder#PrepareSource(s:data)
-  let prompt = (get(s:, 'using_alternative', v:false) ? '*' : '').s:cur_executive.'> '
+  let using_alternative = get(s:, 'using_alternative', v:false) ? '*' : ''
+  let prompt = using_alternative.s:finder.':'.s:cur_executive.'> '
 
   let s:opts = vista#finder#PrepareOpts(source, prompt)
 

--- a/autoload/vista/finder/skim.vim
+++ b/autoload/vista/finder/skim.vim
@@ -1,0 +1,43 @@
+" Actually call skim#run()
+function! s:ApplyRun() abort
+  try
+    " skim_colors may interfere custom syntax.
+    " Unlet and restore it later.
+    if exists('g:skim_colors')
+      let old_skim_colors = g:skim_colors
+      unlet g:skim_colors
+    endif
+
+    call skim#run(skim#wrap(s:opts))
+  finally
+    if exists('l:old_skim_colors')
+      let g:skim_colors = old_skim_colors
+    endif
+  endtry
+endfunction
+
+function! s:Run(...) abort
+  let source = vista#finder#PrepareSource(s:data)
+  let prompt = (get(s:, 'using_alternative', v:false) ? '*' : '').s:cur_executive.'> '
+
+  let s:opts = vista#finder#PrepareOpts(source, prompt)
+
+  call vista#finder#RunFZFOrSkim(function('s:ApplyRun'), 'vista#finder#fzf#Highlight')
+endfunction
+
+" Optional argument: executive, coc or ctags
+" Ctags is the default.
+function! vista#finder#skim#Run(...) abort
+  if !exists('*skim#run')
+    call vista#error#Need('skim')
+    return
+  endif
+
+  let [s:data, s:cur_executive, s:using_alternative] = call('vista#finder#GetSymbols', a:000)
+
+  if s:data is# v:null
+    return vista#util#Warning('Empty data for fzf finder')
+  endif
+
+  call s:Run()
+endfunction

--- a/autoload/vista/finder/skim.vim
+++ b/autoload/vista/finder/skim.vim
@@ -29,14 +29,13 @@ endfunction
 " Ctags is the default.
 function! vista#finder#skim#Run(...) abort
   if !exists('*skim#run')
-    call vista#error#Need('skim')
-    return
+    return vista#error#Need('https://github.com/lotabout/skim')
   endif
 
   let [s:data, s:cur_executive, s:using_alternative] = call('vista#finder#GetSymbols', a:000)
 
   if s:data is# v:null
-    return vista#util#Warning('Empty data for fzf finder')
+    return vista#util#Warning('Empty data for skim finder')
   endif
 
   call s:Run()

--- a/autoload/vista/finder/skim.vim
+++ b/autoload/vista/finder/skim.vim
@@ -22,7 +22,7 @@ function! s:Run(...) abort
 
   let s:opts = vista#finder#PrepareOpts(source, prompt)
 
-  call vista#finder#RunFZFOrSkim(function('s:ApplyRun'), 'vista#finder#fzf#Highlight')
+  call vista#finder#RunFZFOrSkim(function('s:ApplyRun'))
 endfunction
 
 " Optional argument: executive, coc or ctags

--- a/autoload/vista/finder/skim.vim
+++ b/autoload/vista/finder/skim.vim
@@ -1,3 +1,9 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+let s:finder = fnamemodify(expand('<sfile>'), ':t:r')
+
 " Actually call skim#run()
 function! s:ApplyRun() abort
   try
@@ -18,7 +24,8 @@ endfunction
 
 function! s:Run(...) abort
   let source = vista#finder#PrepareSource(s:data)
-  let prompt = (get(s:, 'using_alternative', v:false) ? '*' : '').s:cur_executive.'> '
+  let using_alternative = get(s:, 'using_alternative', v:false) ? '*' : ''
+  let prompt = using_alternative.s:finder.':'.s:cur_executive.'> '
 
   let s:opts = vista#finder#PrepareOpts(source, prompt)
 

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -122,17 +122,20 @@ Vista                                                                      *Vist
 
                                                                     *vista-finder*
 
-  `:Vista finder`:  same with `:Vista finder ctags` .
+  `:Vista finder`:  same with `:Vista finder fzf:ctags` .
 
   `:Vista finder!`: search tags recursively. Note: it's still experimental.
                   What's more, it may be very slow to generate all tags
                   in a whole project.
 
-  You can also specify an executive for the finder, for example:
+  `:Vistaa finder [finder:executive]`: You can specify either the finder or the
+                  executive, or the both, e.g., `:Vista finder skim:ctags` .
 
-  `:Vista finder coc`:   search symbols provided by coc.nvim.
+                  Specify the finder or executive, e.g.,:
 
-  `:Vista finder ctags`: search tags provided by ctags.
+  `:Vista finder fzf`: same with `:Vista finder fzf:ctags` .
+
+  `:Vista finder coc`: same with `:Vista finder fzf:coc` .
 
                                                                       *vista-info*
 


### PR DESCRIPTION
Close #129

The dependency is [skim](https://github.com/lotabout/skim) only, no need to install [skim.vim](https://github.com/lotabout/skim.vim).

`:Vista finder skim:ctags`:

<img width="924" alt="屏幕快照 2019-09-01 下午5 51 25" src="https://user-images.githubusercontent.com/8850248/64074680-27443480-cce1-11e9-9642-9d86feba7ad8.png">
