### PR TITLE
Don't execute async callback if t:vista is not exists

### DIFF
--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -88,6 +88,7 @@ endfunction
 
 function! s:on_exit(_job, _data, _event) abort dict
   if v:dying | return | endif
+  if !exists('t:vista') | return | endif
 
   " Second last line is the real last one in neovim
   call s:ExtractLinewise(self.stdout[:-2])


### PR DESCRIPTION
neovim version: NVIM v0.5.0-10-g0b71bb73e


I've trying to figure out the following error when using fzf tabopen action with autocmd calling `vista#RunForNearestMethodOrFunction`:
```
Error detected while processing function vista#cursor#FindNearestMethodOrFunction:
line    1:
E716: Key not present in Dictionary: source.bufnr
```
Then I figure out that `t:vista` may not exist because of neovim autocmd event order.
neovim may emit `CursorMoved` before `BufRead` when using fzf tabopen
action. Thus vista.vim cannot update buffer info before execute.

This fix might need to be applied to other executives. But I'm not sure where should I add the similiar check for other executives.

