### PR TITLE
update information in README, change ctags install cmd for latest brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ The JSON support for ctags is avaliable if u-ctags is linked to libjansson when 
 - macOS
 
     ```bash
-    $ brew install --with-jansson universal-ctags/universal-ctags/universal-ctags
+    # NOTE: Don't use `brew install ctags`, which is not supported by the vista.vim
+    $ brew install --HEAD universal-ctags/universal-ctags/universal-ctags
     ```
 
 - Ubuntu


### PR DESCRIPTION
The following brew install cmd is not supported in the latest brew (2.1.11), besides the default ctags are not supported for vista either, maybe warning this to the mac users are more user-friendly.
```
    $ brew install --with-jansson universal-ctags/universal-ctags/universal-ctags
```