### PR TITLE
doc: remove / from the list of command

### DIFF
--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -420,12 +420,16 @@ Key Mappings                                                  *vista-key-mapping
 The following mappings are defined by default in the vista window.
 
 <CR>  - jump to the tag under the cursor.
-/     - open the vista finder.
 p     - preview the tag under the context via the floating window if it's
         avaliable.
 s     - sort the symbol alphabetically or the location they are declared.
 q     - close the vista window.
 
+You can add a mapping to `/` in order to open the vista finder for
+searching by adding the following autocommand in your vimrc:
+ >
+ autocmd FileType vista,vista_kind nnoremap <buffer> <silent> \
+             / :<c-u>call vista#finder#fzf#Run()<CR>
 ================================================================================
 CONTRIBUTING                                                  *vista-contributing*
 


### PR DESCRIPTION
The `/` command was removed in 2662f45ef.
Also add documentation about how to add the mapping again.