### PR TITLE
Support DocumentSymbol type in vim_lsp executive

### DIFF
--- a/autoload/vista/parser/lsp.vim
+++ b/autoload/vista/parser/lsp.vim
@@ -45,16 +45,35 @@ endfunction
 " should transform the number to the symbol text first.
 function! vista#parser#lsp#KindToSymbol(line, container) abort
   let line = a:line
-  let location = line.location
-  if s:IsFileUri(location.uri)
-    let lnum = location.range.start.line + 1
-    let col = location.range.start.character + 1
+  " SymbolInformation interface
+  if has_key(line, 'location')
+    let location = line.location
+    if s:IsFileUri(location.uri)
+      let lnum = location.range.start.line + 1
+      let col = location.range.start.character + 1
+      call add(a:container, {
+         \ 'lnum': lnum,
+         \ 'col': col,
+         \ 'kind': s:Kind2Symbol(line.kind),
+         \ 'text': line.name,
+         \ })
+    endif
+  " DocumentSymbol class
+  elseif has_key(line, 'range')
+    let range = line.range
+    let lnum = range.start.line + 1
+    let col = range.start.character + 1
     call add(a:container, {
-        \ 'lnum': lnum,
-        \ 'col': col,
-        \ 'kind': s:Kind2Symbol(line.kind),
-        \ 'text': line.name,
-        \ })
+          \ 'lnum': lnum,
+          \ 'col': col,
+          \ 'kind': s:Kind2Symbol(line.kind),
+          \ 'text': line.name,
+          \ })
+    if has_key(line, 'children')
+      for child in line.children
+        call vista#parser#lsp#KindToSymbol(child, a:container)
+      endfor
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
According to the [document](https://microsoft.github.io//language-server-protocol/specifications/specification-3-14/#textDocument_documentSymbol), response type of `Document Symbols` request is `DocumentSymbol[] | SymbolInformation[] | null`. Current implementation only supports `SymbolInformation`, so I added `DocumentSymbol` support.

Tested in `vim-lsp` and golang(`gopls`) with `:Vista vim_lsp` command.