### PR TITLE
Generate tags for anonymous entities (C/C++)

### DIFF
--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -46,7 +46,14 @@ function! s:BuildCmd(file) abort
   let ft = &filetype
 
   " Refer to tagbar
-  let common_opt = '--format=2 --excmd=pattern --fields=nksSaf --extras= --file-scope=yes --sort=no --append=no'
+  let common_opt = '--format=2 --excmd=pattern --fields=nksSaf --file-scope=yes --sort=no --append=no'
+
+  " Do not pass --extras in order to let uctags handle the tags for anonymous
+  " entities correctly.
+  if t:vista.source.filetype() !=# 'c' && t:vista.source.filetype() !=# 'cpp'
+    let common_opt .= ' --extras= '
+  endif
+
   let language_specific_opt = s:GetLanguageSpecificOptition(ft)
 
   if s:support_json_format

--- a/autoload/vista/renderer/default.vim
+++ b/autoload/vista/renderer/default.vim
@@ -255,29 +255,6 @@ function! s:Render() abort
 
   let without_scope = t:vista.without_scope
 
-  " Build psedu tags for cpp anonymous namespace tags . Ref #83
-  let ft_having_anonymous_tags = ['cpp', 'c']
-  if index(ft_having_anonymous_tags, t:vista.source.filetype()) > -1
-    let anons = []
-
-    for ws in t:vista.with_scope
-      if ws.scope =~# '^__anon' && index(anons,  ws.scope) == -1
-        call add(anons, ws.scope)
-      endif
-    endfor
-
-    let psedu_anonymous_cpp_namespace_tags = []
-
-    for anon in anons
-      let ps = filter(copy(t:vista.with_scope), 'v:val.scope ==# anon')
-      let p = ps[0]
-      let line = str2nr(p.line) - 1
-      call add(psedu_anonymous_cpp_namespace_tags, { 'name': p.scope, 'kind': p.scopeKind, 'line': line })
-    endfor
-
-    call extend(without_scope, psedu_anonymous_cpp_namespace_tags)
-  endif
-
   " The root of hierarchy structure doesn't have scope field.
   for potential_root_line in without_scope
 


### PR DESCRIPTION
Since UCtags can generate anonymous tags itself (and I belive it's the only ctags implementation that works with Vista) it's possible to dump manual __anon tags generation at all.

Sample C++ file:

```
struct {
	int bar;
} anon;

namespace example {
	struct {
		int foo;
	};

	struct {
		int bar;
	};

	enum {
		FOO
	};

	enum {
		BAR
	};
}

namespace {
	enum {
		BAZ
	};
}

int
main(void)
{
	return 0;
}
```

This commit also fixes numerous bugs (e.g. Vista can't handle two anonymous enums in a single namespace).