### PR TITLE
Prevent floating_win from show up in other window

### DIFF
--- a/autoload/vista/floating.vim
+++ b/autoload/vista/floating.vim
@@ -97,8 +97,11 @@ function! s:CloseOnWinEnter() abort
   let t:vista.floating_visible = v:false
 endfunction
 
-function! s:Display(msg) abort
+function! s:Display(msg, win_id) abort
   let msg = a:msg
+  if a:win_id !=# win_getid()
+    return
+  endif
 
   if !exists('s:floating_bufnr') || !bufexists(s:floating_bufnr)
     let s:floating_bufnr = nvim_create_buf(v:false, v:false)
@@ -194,8 +197,9 @@ function! vista#floating#DisplayAt(lnum, tag) abort
   let s:last_lnum = a:lnum
 
   let [lines, s:floating_lnum] = vista#util#GetPreviewLines(a:lnum)
+  let win_id = win_getid()
 
-  let s:floating_timer = timer_start(s:floating_delay, { -> s:Display(lines)})
+  let s:floating_timer = timer_start(s:floating_delay, { -> s:Display(lines, win_id)})
 endfunction
 
 " Display in floating_win given the lnum of source buffer and raw lines.
@@ -205,6 +209,7 @@ function! vista#floating#DisplayRawAt(lnum, lines) abort
   endif
 
   let s:last_lnum = a:lnum
+  let win_id = win_getid()
 
-  let s:floating_timer = timer_start(s:floating_delay, { -> s:Display(a:lines)})
+  let s:floating_timer = timer_start(s:floating_delay, { -> s:Display(a:lines, win_id)})
 endfunction

--- a/autoload/vista/popup.vim
+++ b/autoload/vista/popup.vim
@@ -63,7 +63,11 @@ function! s:OpenPopup(lines) abort
   endif
 endfunction
 
-function! s:DisplayRawAt(lnum, lines) abort
+function! s:DisplayRawAt(lnum, lines, vista_winid) abort
+  if win_getid() != a:vista_winid
+    return
+  endif
+
   let s:max_length = max(map(copy(a:lines), 'strlen(v:val)')) + 2
   call s:OpenPopup(a:lines)
 
@@ -76,7 +80,11 @@ function! s:DisplayRawAt(lnum, lines) abort
   let t:vista.popup_visible = v:true
 endfunction
 
-function! s:DisplayAt(lnum, tag) abort
+function! s:DisplayAt(lnum, tag, vista_winid) abort
+  if win_getid() != a:vista_winid
+    return
+  endif
+
   let [lines, s:popup_lnum] = vista#util#GetPreviewLines(a:lnum)
 
   let s:max_length = max(map(copy(lines), 'strlen(v:val)')) + 2
@@ -120,7 +128,7 @@ function! s:DispatchDisplayer(Displayer, lnum, tag_or_raw_lines) abort
 
   let s:popup_timer = timer_start(
         \ s:popup_delay,
-        \ { -> a:Displayer(a:lnum, a:tag_or_raw_lines) }
+        \ { -> a:Displayer(a:lnum, a:tag_or_raw_lines, win_getid()) }
         \ )
 endfunction
 


### PR DESCRIPTION
Check whether the user is still in the Vista window before displaying the floating window. Fixes #194