### PR TITLE
Refactoring cursor.vim

### DIFF
--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -48,26 +48,6 @@ function! vista#OnExecute(provider, AUF) abort
   call vista#autocmd#Init('Vista'.vista#util#ToCamelCase(a:provider), a:AUF)
 endfunction
 
-" call Run in the window win unsilently, unlike win_execute() which uses
-" silent by default.
-"
-" CocAction only fetch symbols for current document, no way for specify the other at the moment.
-" workaround for #52
-"
-" see also #71
-function! vista#WinExecute(winnr, Run, ...) abort
-  if winnr() != a:winnr
-    noautocmd execute a:winnr.'wincmd w'
-    let l:switch_back = 1
-  endif
-
-  call call(a:Run, a:000)
-
-  if exists('l:switch_back')
-    noautocmd wincmd p
-  endif
-endfunction
-
 " Sort the items under some kind alphabetically.
 function! vista#Sort() abort
   if !has_key(t:vista, 'sort')
@@ -190,7 +170,7 @@ function! vista#(bang, ...) abort
     elseif a:1 ==# 'focus'
       call vista#sidebar#ToggleFocus()
     elseif a:1 ==# 'show'
-      if vista#sidebar#IsVisible()
+      if vista#sidebar#IsOpen()
         call vista#cursor#ShowTag()
       else
         call vista#sidebar#Open()

--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -118,14 +118,6 @@ function! vista#GetExplicitExecutiveOrDefault() abort
   return executive
 endfunction
 
-function! vista#GenericCloseOverlay() abort
-  if exists('*nvim_open_win')
-    call vista#floating#Close()
-  elseif exists('*popup_create')
-    call vista#popup#Close()
-  endif
-endfunction
-
 " Used for running vista.vim on startup
 function! vista#RunForNearestMethodOrFunction() abort
   let [bufnr, winnr, fname, fpath] = [bufnr('%'), winnr(), expand('%'), expand('%:p')]

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -104,11 +104,7 @@ function! s:HighlightNearestTag(_timer) abort
   let s:last_vlnum = s:vlnum
 
   let tag = get(found, 'name', v:null)
-  if !empty(tag)
-    call vista#WinExecute(winnr, function('vista#highlight#Add'), s:vlnum, v:true, tag)
-  else
-    call vista#WinExecute(winnr, function('vista#highlight#Add'), s:vlnum, v:true)
-  endif
+  call vista#WinExecute(winnr, function('vista#highlight#Add'), s:vlnum, v:true, tag)
 endfunction
 
 " Fold or unfold when meets the top level tag line
@@ -227,11 +223,7 @@ function! vista#cursor#ShowTagFor(lnum) abort
   endif
 
   let tag = get(found, 'name', v:null)
-  if !empty(tag)
-    call vista#highlight#Add(s:vlnum, v:true, tag)
-  else
-    call vista#highlight#Add(s:vlnum, v:true)
-  endif
+  call vista#highlight#Add(s:vlnum, v:true, tag)
 endfunction
 
 function! vista#cursor#ShowTag() abort

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -64,7 +64,7 @@ function! s:FindNearestMethodOrFunction(_timer) abort
 
   call s:StopHighlightTimer()
 
-  if vista#sidebar#IsVisible()
+  if vista#sidebar#IsOpen()
     let s:highlight_timer = timer_start(200, function('s:HighlightNearestTag'))
   endif
 endfunction
@@ -104,7 +104,7 @@ function! s:HighlightNearestTag(_timer) abort
   let s:last_vlnum = s:vlnum
 
   let tag = get(found, 'name', v:null)
-  call vista#WinExecute(winnr, function('vista#highlight#Add'), s:vlnum, v:true, tag)
+  call vista#win#Execute(winnr, function('vista#highlight#Add'), s:vlnum, v:true, tag)
 endfunction
 
 " Fold or unfold when meets the top level tag line

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -48,84 +48,6 @@ function! s:GetInfoUnderCursor() abort
   endif
 endfunction
 
-function! s:EchoScope(scope) abort
-  if g:vista#renderer#enable_icon
-    echohl Function | echo ' '.a:scope.': ' | echohl NONE
-  else
-    echohl Function  | echo '['.a:scope.'] '  | echohl NONE
-  endif
-endfunction
-
-function! s:EchoScopeFromCacheIsOk() abort
-  if has_key(t:vista, 'vlnum_cache')
-    " should exclude the first two lines and keep in mind that the 1-based and
-    " 0-based.
-    " This is really error prone.
-    let tagline = get(t:vista.vlnum_cache, line('.') - 3, '')
-    if !empty(tagline)
-      if has_key(tagline, 'scope')
-        call s:EchoScope(tagline.scope)
-      else
-        call s:EchoScope(tagline.kind)
-      endif
-      return v:true
-    endif
-  endif
-  return v:false
-endfunction
-
-function! s:TryParseAndEchoScope() abort
-  let linenr = vista#util#LowerIndentLineNr()
-
-  " Echo the scope of current tag if found
-  if linenr != 0
-    let scope = matchstr(getline(linenr), '\a\+$')
-    if !empty(scope)
-      call s:EchoScope(scope)
-    else
-      " For the kind renderer
-      let pieces = split(getline(linenr), ' ')
-      if !empty(pieces)
-        let scope = pieces[1]
-        call s:EchoScope(scope)
-      endif
-    endif
-  endif
-endfunction
-
-" Echo the tag with detailed info in the cmdline
-" Try to echo the scope and then the tag.
-function! s:EchoInCmdline(msg, tag) abort
-  let [msg, tag] = [a:msg, a:tag]
-
-  " Case II:\@ $R^2 \geq Q^3$ :  paragraph:175
-  try
-    let [_, start, end] = matchstrpos(msg, '\C'.tag)
-
-    " If couldn't find the tag in the msg
-    if start == -1
-      echohl Function | echo msg | echohl NONE
-      return
-    endif
-  catch /^Vim\%((\a\+)\)\=:E869/
-    echohl Function | echo msg | echohl NONE
-    return
-  endtry
-
-  " Try highlighting the scope of current tag
-  if !s:EchoScopeFromCacheIsOk()
-    call s:TryParseAndEchoScope()
-  endif
-
-  " if start is 0, msg[0:-1] will display the redundant whole msg.
-  if start != 0
-    echohl Statement | echon msg[0 : start-1] | echohl NONE
-  endif
-
-  echohl Search    | echon msg[start : end-1] | echohl NONE
-  echohl Statement | echon msg[end : ]        | echohl NONE
-endfunction
-
 function! s:DisplayInFloatingWin(...) abort
   if s:has_popup
     call call('vista#popup#DisplayAt', a:000)
@@ -167,13 +89,13 @@ function! s:ShowDetail() abort
   let lnum = s:GetTrailingLnum()
 
   if strategy ==# s:echo_cursor_opts[0]
-    call s:EchoInCmdline(msg, tag)
+    call vista#echo#EchoInCmdline(msg, tag)
   elseif strategy ==# s:echo_cursor_opts[1]
     call s:DisplayInFloatingWin(lnum, tag)
   elseif strategy ==# s:echo_cursor_opts[2]
     call s:PeekInSourceFile(lnum, tag)
   elseif strategy ==# s:echo_cursor_opts[3]
-    call s:EchoInCmdline(msg, tag)
+    call vista#echo#EchoInCmdline(msg, tag)
     if s:has_floating_win
       call s:DisplayInFloatingWin(lnum, tag)
     else
@@ -345,20 +267,6 @@ function! vista#cursor#NearestSymbol() abort
   return vista#util#BinarySearch(t:vista.raw, line('.'), 'line', 'name')
 endfunction
 
-function! s:EchoScopeInCmdlineIsOk() abort
-  let cur_line = getline('.')
-  if cur_line[-1:] ==# ']'
-    let splitted = split(cur_line)
-    " Join the scope parts in case of they contains spaces, e.g., structure names
-    let scope = join(splitted[1:-2], ' ')
-    let cnt = matchstr(splitted[-1], '\d\+')
-    call s:EchoScope(scope)
-    echohl Keyword | echon cnt | echohl NONE
-    return v:true
-  endif
-  return v:false
-endfunction
-
 " Show the folded content if in a closed fold.
 function! s:ShowFoldedDetailIsOk() abort
   if foldclosed('.') != -1
@@ -381,7 +289,7 @@ endfunction
 
 function! vista#cursor#ShowDetail(_timer) abort
   if empty(getline('.'))
-        \ || s:EchoScopeInCmdlineIsOk()
+        \ || vista#echo#EchoScopeInCmdlineIsOk()
         \ || s:ShowFoldedDetailIsOk()
     return
   endif

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -58,22 +58,6 @@ function! s:DisplayInFloatingWin(...) abort
   endif
 endfunction
 
-function! s:ApplyPeek(lnum, tag) abort
-  silent execute 'normal!' a:lnum.'z.'
-  let [_, start, _] = matchstrpos(getline('.'), a:tag)
-  call vista#util#Blink(1, 100, [a:lnum, start+1, strlen(a:tag)])
-endfunction
-
-if exists('*win_execute')
-  function! s:PeekInSourceFile(lnum, tag) abort
-    call win_execute(bufwinid(t:vista.source.bufnr), 'noautocmd call s:ApplyPeek(a:lnum, a:tag)')
-  endfunction
-else
-  function! s:PeekInSourceFile(lnum, tag) abort
-    call vista#WinExecute(t:vista.source.winnr(), function('s:ApplyPeek'), a:lnum, a:tag)
-  endfunction
-endif
-
 " Show the detail of current tag/symbol under cursor.
 function! s:ShowDetail() abort
   let [tag, source_line] = s:GetInfoUnderCursor()
@@ -93,13 +77,13 @@ function! s:ShowDetail() abort
   elseif strategy ==# s:echo_cursor_opts[1]
     call s:DisplayInFloatingWin(lnum, tag)
   elseif strategy ==# s:echo_cursor_opts[2]
-    call s:PeekInSourceFile(lnum, tag)
+    call vista#source#PeekSymbol(lnum, tag)
   elseif strategy ==# s:echo_cursor_opts[3]
     call vista#echo#EchoInCmdline(msg, tag)
     if s:has_floating_win
       call s:DisplayInFloatingWin(lnum, tag)
     else
-      call s:PeekInSourceFile(lnum, tag)
+      call vista#source#PeekSymbol(lnum, tag)
     endif
   else
     call vista#error#InvalidOption('g:vista_echo_cursor_strategy', s:echo_cursor_opts)

--- a/autoload/vista/cursor.vim
+++ b/autoload/vista/cursor.vim
@@ -89,7 +89,7 @@ function! s:ShowDetail() abort
     call vista#error#InvalidOption('g:vista_echo_cursor_strategy', s:echo_cursor_opts)
   endif
 
-  call s:ApplyHighlight(line('.'), v:false, tag)
+  call vista#highlight#Add(line('.'), v:false, tag)
 endfunction
 
 function! s:Compare(s1, s2) abort
@@ -123,44 +123,6 @@ function! s:HasVlnum() abort
         \ && has_key(t:vista.raw[0], 'vlnum')
 endfunction
 
-" Highlight the line given the line number and ensure it's visible if required.
-"
-" lnum - current line number in vista window
-" ensure_visible - kepp this line visible
-" optional: tag - accurate tag
-function! s:ApplyHighlight(lnum, ensure_visible, ...) abort
-  if exists('w:vista_highlight_id')
-    call matchdelete(w:vista_highlight_id)
-    unlet w:vista_highlight_id
-  endif
-
-  if get(g:, 'vista_highlight_whole_line', 0)
-    let hi_pos = a:lnum
-  else
-    let cur_line = getline(a:lnum)
-    " Current line may contains +,-,~, use `\S` is incorrect to find the right
-    " starting postion.
-    let [_, start, _] = matchstrpos(cur_line, '[a-zA-Z0-9_,#:]')
-
-    " If we know the tag, then what we have to do is to use the length of tag
-    " based on the starting point.
-    "
-    " start is 0-based, while the column used in matchstrpos is 1-based.
-    if a:0 == 1
-      let hi_pos = [a:lnum, start+1, strlen(a:1)]
-    else
-      let [_, end, _] = matchstrpos(cur_line, ':\d\+$')
-      let hi_pos = [a:lnum, start+1, end - start]
-    endif
-  endif
-
-  let w:vista_highlight_id = matchaddpos('IncSearch', [hi_pos])
-
-  if a:ensure_visible
-    execute 'normal!' a:lnum.'z.'
-  endif
-endfunction
-
 " Highlight the nearest tag in the vista window.
 function! s:HighlightNearestTag(_timer) abort
   if !exists('t:vista')
@@ -190,9 +152,9 @@ function! s:HighlightNearestTag(_timer) abort
 
   let tag = get(found, 'name', v:null)
   if !empty(tag)
-    call vista#WinExecute(winnr, function('s:ApplyHighlight'), s:vlnum, v:true, tag)
+    call vista#WinExecute(winnr, function('vista#highlight#Add'), s:vlnum, v:true, tag)
   else
-    call vista#WinExecute(winnr, function('s:ApplyHighlight'), s:vlnum, v:true)
+    call vista#WinExecute(winnr, function('vista#highlight#Add'), s:vlnum, v:true)
   endif
 endfunction
 
@@ -307,9 +269,9 @@ function! vista#cursor#ShowTagFor(lnum) abort
 
   let tag = get(found, 'name', v:null)
   if !empty(tag)
-    call s:ApplyHighlight(s:vlnum, v:true, tag)
+    call vista#highlight#Add(s:vlnum, v:true, tag)
   else
-    call s:ApplyHighlight(s:vlnum, v:true)
+    call vista#highlight#Add(s:vlnum, v:true)
   endif
 endfunction
 

--- a/autoload/vista/cursor/ctags.vim
+++ b/autoload/vista/cursor/ctags.vim
@@ -1,0 +1,65 @@
+" Try matching the exact tag given the trimmed line in the vista window.
+function! s:MatchTag(trimmed_line) abort
+  " Since we include the space ` `, we need to trim the result later.
+  " / --> github.com/golang/dep/gps:11
+  if t:vista.provider ==# 'markdown'
+    let matched = matchlist(a:trimmed_line, '\([a-zA-Z:#_.,/<> ]\-\+\)\(H\d:\d\+\)$')
+  else
+    let matched = matchlist(a:trimmed_line, '\([a-zA-Z:#_.,/<> ]\-\+\):\(\d\+\)$')
+  endif
+
+  return get(matched, 1, '')
+endfunction
+
+function! s:RemoveVisibility(tag) abort
+  if index(['+', '~', '-'], a:tag[0]) > -1
+    return a:tag[1:]
+  else
+    return a:tag
+  endif
+endfunction
+
+function! vista#cursor#ctags#GetInfo() abort
+  let raw_cur_line = getline('.')
+
+  if empty(raw_cur_line)
+    return [v:null, v:null]
+  endif
+
+  " tag like s:StopCursorTimer has `:`, so we can't simply use split(tag, ':')
+  let last_semicoln_idx = strridx(raw_cur_line, ':')
+  let lnum = raw_cur_line[last_semicoln_idx+1:]
+
+  let source_line = t:vista.source.line_trimmed(lnum)
+  if empty(source_line)
+    return [v:null, v:null]
+  endif
+
+  " For scoped tag
+  " Currently vlnum_cache is ctags provider only.
+  if has_key(t:vista, 'vlnum_cache') && t:vista.provider ==# 'ctags'
+    let tagline = t:vista.get_tagline_under_cursor()
+    if !empty(tagline)
+      return [tagline.name, source_line]
+    endif
+  endif
+
+  " For scopeless tag
+  " peer_ilog(PEER,FORMAT,...):90
+  let trimmed_line = vista#util#Trim(raw_cur_line)
+  let left_parenthsis_idx = stridx(trimmed_line, '(')
+  if left_parenthsis_idx > -1
+    " Ignore the visibility symbol, e.g., +test2()
+    let tag = s:RemoveVisibility(trimmed_line[0 : left_parenthsis_idx-1])
+    return [tag, source_line]
+  endif
+
+  let tag = s:MatchTag(trimmed_line)
+  if empty(tag)
+    let tag = raw_cur_line[:last_semicoln_idx-1]
+  endif
+
+  let tag = s:RemoveVisibility(vista#util#Trim(tag))
+
+  return [tag, source_line]
+endfunction

--- a/autoload/vista/cursor/ctags.vim
+++ b/autoload/vista/cursor/ctags.vim
@@ -1,3 +1,7 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
 " Try matching the exact tag given the trimmed line in the vista window.
 function! s:MatchTag(trimmed_line) abort
   " Since we include the space ` `, we need to trim the result later.

--- a/autoload/vista/cursor/lsp.vim
+++ b/autoload/vista/cursor/lsp.vim
@@ -1,0 +1,47 @@
+function! s:GetTagInfoFromLSPAndExtension() abort
+  let raw_cur_line = getline('.')
+
+  " TODO use range info of LSP symbols?
+  if t:vista.provider ==# 'coc'
+    let tag = vista#util#Trim(raw_cur_line[:stridx(raw_cur_line, ':')-1])
+    return [tag, v:true]
+  elseif t:vista.provider ==# 'markdown' || t:vista.provider ==# 'rst'
+    if line('.') < 3
+      return [v:null, v:true]
+    endif
+    " The first two lines are for displaying fpath. the lnum is 1-based, while
+    " idex is 0-based.
+    " So it's line('.') - 3 instead of line('.').
+    let tag = vista#extension#{t:vista.provider}#GetHeader(line('.')-3)
+    if tag is# v:null
+      return [v:null, v:true]
+    endif
+    return [tag, v:true]
+  endif
+
+  return [v:null, v:false]
+endfunction
+
+function! vista#cursor#lsp#GetInfo() abort
+  let raw_cur_line = getline('.')
+
+  if empty(raw_cur_line)
+    return [v:null, v:null]
+  endif
+
+  " tag like s:StopCursorTimer has `:`, so we can't simply use split(tag, ':')
+  let last_semicoln_idx = strridx(raw_cur_line, ':')
+  let lnum = raw_cur_line[last_semicoln_idx+1:]
+
+  let source_line = t:vista.source.line_trimmed(lnum)
+  if empty(source_line)
+    return [v:null, v:null]
+  endif
+
+  let [tag, should_return] = s:GetTagInfoFromLSPAndExtension()
+  if should_return
+    return tag is# v:null ? [v:null, v:null] : [tag, source_line]
+  endif
+
+  return [v:null, v:null]
+endfunction

--- a/autoload/vista/cursor/lsp.vim
+++ b/autoload/vista/cursor/lsp.vim
@@ -1,3 +1,7 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
 function! s:GetTagInfoFromLSPAndExtension() abort
   let raw_cur_line = getline('.')
 

--- a/autoload/vista/cursor/lsp.vim
+++ b/autoload/vista/cursor/lsp.vim
@@ -2,28 +2,28 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-function! s:GetTagInfoFromLSPAndExtension() abort
+function! s:GetInfoFromLSPAndExtension() abort
   let raw_cur_line = getline('.')
 
   " TODO use range info of LSP symbols?
   if t:vista.provider ==# 'coc'
     let tag = vista#util#Trim(raw_cur_line[:stridx(raw_cur_line, ':')-1])
-    return [tag, v:true]
+    return tag
   elseif t:vista.provider ==# 'markdown' || t:vista.provider ==# 'rst'
     if line('.') < 3
-      return [v:null, v:true]
+      return v:null
     endif
     " The first two lines are for displaying fpath. the lnum is 1-based, while
     " idex is 0-based.
     " So it's line('.') - 3 instead of line('.').
     let tag = vista#extension#{t:vista.provider}#GetHeader(line('.')-3)
     if tag is# v:null
-      return [v:null, v:true]
+      return v:null
     endif
-    return [tag, v:true]
+    return tag
   endif
 
-  return [v:null, v:false]
+  return v:null
 endfunction
 
 function! vista#cursor#lsp#GetInfo() abort
@@ -42,10 +42,7 @@ function! vista#cursor#lsp#GetInfo() abort
     return [v:null, v:null]
   endif
 
-  let [tag, should_return] = s:GetTagInfoFromLSPAndExtension()
-  if should_return
-    return tag is# v:null ? [v:null, v:null] : [tag, source_line]
-  endif
+  let tag = s:GetInfoFromLSPAndExtension()
 
-  return [v:null, v:null]
+  return [tag, source_line]
 endfunction

--- a/autoload/vista/echo.vim
+++ b/autoload/vista/echo.vim
@@ -1,0 +1,83 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+scriptencoding utf8
+
+function! s:EchoScope(scope) abort
+  if g:vista#renderer#enable_icon
+    echohl Function | echo ' '.a:scope.': ' | echohl NONE
+  else
+    echohl Function  | echo '['.a:scope.'] '  | echohl NONE
+  endif
+endfunction
+
+function! s:TryParseAndEchoScope() abort
+  let linenr = vista#util#LowerIndentLineNr()
+
+  " Echo the scope of current tag if found
+  if linenr != 0
+    let scope = matchstr(getline(linenr), '\a\+$')
+    if !empty(scope)
+      call s:EchoScope(scope)
+    else
+      " For the kind renderer
+      let pieces = split(getline(linenr), ' ')
+      if !empty(pieces)
+        let scope = pieces[1]
+        call s:EchoScope(scope)
+      endif
+    endif
+  endif
+endfunction
+
+function! vista#echo#EchoScopeFromCacheIsOk() abort
+  if has_key(t:vista, 'vlnum_cache')
+    " should exclude the first two lines and keep in mind that the 1-based and
+    " 0-based.
+    " This is really error prone.
+    let tagline = get(t:vista.vlnum_cache, line('.') - 3, '')
+    if !empty(tagline)
+      if has_key(tagline, 'scope')
+        call s:EchoScope(tagline.scope)
+      else
+        call s:EchoScope(tagline.kind)
+      endif
+      return v:true
+    endif
+  endif
+  return v:false
+endfunction
+
+" Echo the tag with detailed info in the cmdline
+" Try to echo the scope and then the tag.
+function! vista#echo#EchoInCmdline(msg, tag) abort
+  let [msg, tag] = [a:msg, a:tag]
+
+  " Case II:\@ $R^2 \geq Q^3$ :  paragraph:175
+  try
+    let [_, start, end] = matchstrpos(msg, '\C'.tag)
+
+    " If couldn't find the tag in the msg
+    if start == -1
+      echohl Function | echo msg | echohl NONE
+      return
+    endif
+  catch /^Vim\%((\a\+)\)\=:E869/
+    echohl Function | echo msg | echohl NONE
+    return
+  endtry
+
+  " Try highlighting the scope of current tag
+  if !vista#echo#EchoScopeFromCacheIsOk()
+    call s:TryParseAndEchoScope()
+  endif
+
+  " if start is 0, msg[0:-1] will display the redundant whole msg.
+  if start != 0
+    echohl Statement | echon msg[0 : start-1] | echohl NONE
+  endif
+
+  echohl Search    | echon msg[start : end-1] | echohl NONE
+  echohl Statement | echon msg[end : ]        | echohl NONE
+endfunction

--- a/autoload/vista/echo.vim
+++ b/autoload/vista/echo.vim
@@ -31,6 +31,20 @@ function! s:TryParseAndEchoScope() abort
   endif
 endfunction
 
+function! vista#echo#EchoScopeInCmdlineIsOk() abort
+  let cur_line = getline('.')
+  if cur_line[-1:] ==# ']'
+    let splitted = split(cur_line)
+    " Join the scope parts in case of they contains spaces, e.g., structure names
+    let scope = join(splitted[1:-2], ' ')
+    let cnt = matchstr(splitted[-1], '\d\+')
+    call s:EchoScope(scope)
+    echohl Keyword | echon cnt | echohl NONE
+    return v:true
+  endif
+  return v:false
+endfunction
+
 function! vista#echo#EchoScopeFromCacheIsOk() abort
   if has_key(t:vista, 'vlnum_cache')
     " should exclude the first two lines and keep in mind that the 1-based and

--- a/autoload/vista/executive/coc.vim
+++ b/autoload/vista/executive/coc.vim
@@ -83,7 +83,7 @@ endfunction
 function! vista#executive#coc#Run(_fpath) abort
   if exists('*CocAction')
     call vista#SetProvider(s:provider)
-    call vista#WinExecute(t:vista.source.winnr(), function('s:Run'))
+    call vista#win#Execute(t:vista.source.winnr(), function('s:Run'))
     return s:data
   endif
 endfunction

--- a/autoload/vista/executive/lcn.vim
+++ b/autoload/vista/executive/lcn.vim
@@ -40,7 +40,7 @@ endfunction
 function! s:RunAsync() abort
   if exists('*LanguageClient#textDocument_documentSymbol')
     call vista#SetProvider(s:provider)
-    call vista#WinExecute(
+    call vista#win#Execute(
           \ t:vista.source.winnr(),
           \ function('LanguageClient#textDocument_documentSymbol'),
           \ {'handle': v:false},

--- a/autoload/vista/highlight.vim
+++ b/autoload/vista/highlight.vim
@@ -1,0 +1,41 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
+
+" Highlight the line given the line number and ensure it's visible if required.
+"
+" lnum - current line number in vista window
+" ensure_visible - kepp this line visible
+" optional: tag - accurate tag
+function! vista#highlight#Add(lnum, ensure_visible, ...) abort
+  if exists('w:vista_highlight_id')
+    call matchdelete(w:vista_highlight_id)
+    unlet w:vista_highlight_id
+  endif
+
+  if get(g:, 'vista_highlight_whole_line', 0)
+    let hi_pos = a:lnum
+  else
+    let cur_line = getline(a:lnum)
+    " Current line may contains +,-,~, use `\S` is incorrect to find the right
+    " starting postion.
+    let [_, start, _] = matchstrpos(cur_line, '[a-zA-Z0-9_,#:]')
+
+    " If we know the tag, then what we have to do is to use the length of tag
+    " based on the starting point.
+    "
+    " start is 0-based, while the column used in matchstrpos is 1-based.
+    if a:0 == 1
+      let hi_pos = [a:lnum, start+1, strlen(a:1)]
+    else
+      let [_, end, _] = matchstrpos(cur_line, ':\d\+$')
+      let hi_pos = [a:lnum, start+1, end - start]
+    endif
+  endif
+
+  let w:vista_highlight_id = matchaddpos('IncSearch', [hi_pos])
+
+  if a:ensure_visible
+    execute 'normal!' a:lnum.'z.'
+  endif
+endfunction

--- a/autoload/vista/highlight.vim
+++ b/autoload/vista/highlight.vim
@@ -7,7 +7,7 @@
 " lnum - current line number in vista window
 " ensure_visible - kepp this line visible
 " optional: tag - accurate tag
-function! vista#highlight#Add(lnum, ensure_visible, ...) abort
+function! vista#highlight#Add(lnum, ensure_visible, tag) abort
   if exists('w:vista_highlight_id')
     call matchdelete(w:vista_highlight_id)
     unlet w:vista_highlight_id
@@ -25,8 +25,8 @@ function! vista#highlight#Add(lnum, ensure_visible, ...) abort
     " based on the starting point.
     "
     " start is 0-based, while the column used in matchstrpos is 1-based.
-    if a:0 == 1
-      let hi_pos = [a:lnum, start+1, strlen(a:1)]
+    if !empty(a:tag)
+      let hi_pos = [a:lnum, start+1, strlen(a:tag)]
     else
       let [_, end, _] = matchstrpos(cur_line, ':\d\+$')
       let hi_pos = [a:lnum, start+1, end - start]

--- a/autoload/vista/jump.vim
+++ b/autoload/vista/jump.vim
@@ -31,7 +31,7 @@ function! vista#jump#TagLine(tag) abort
 
   call call('vista#util#Blink', get(g:, 'vista_top_level_blink', [2, 100]))
 
-  call vista#GenericCloseOverlay()
+  call vista#win#CloseFloating()
 
   if get(g:, 'vista_close_on_jump', 0)
     call vista#sidebar#Close()
@@ -79,11 +79,11 @@ function! s:ApplyJump(lnum) abort
 endfunction
 
 function! vista#jump#NextTopLevel() abort
-  call vista#GenericCloseOverlay()
+  call vista#win#CloseFloating()
   call s:ApplyJump(s:NextTopLevelLnum())
 endfunction
 
 function! vista#jump#PrevTopLevel() abort
-  call vista#GenericCloseOverlay()
+  call vista#win#CloseFloating()
   call s:ApplyJump(s:PrevTopLevelLnum())
 endfunction

--- a/autoload/vista/lsp.vim
+++ b/autoload/vista/lsp.vim
@@ -1,0 +1,6 @@
+let s:request = {}
+
+function! s:request.ale() abort
+endfunction
+
+function! vista#lsp#request('ale')

--- a/autoload/vista/lsp.vim
+++ b/autoload/vista/lsp.vim
@@ -1,6 +1,0 @@
-let s:request = {}
-
-function! s:request.ale() abort
-endfunction
-
-function! vista#lsp#request('ale')

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -101,7 +101,7 @@ function! vista#sidebar#Close() abort
 
   call s:ClearAugroups('VistaCoc', 'VistaCtags')
 
-  call vista#GenericCloseOverlay()
+  call vista#win#CloseFloating()
 endfunction
 
 function! s:ClearAugroups(...) abort

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -125,7 +125,7 @@ function! vista#sidebar#Open() abort
   endif
 endfunction
 
-function! vista#sidebar#IsVisible() abort
+function! vista#sidebar#IsOpen() abort
   return bufwinnr('__vista__') != -1
 endfunction
 
@@ -143,7 +143,7 @@ function! vista#sidebar#ToggleFocus() abort
 endfunction
 
 function! vista#sidebar#Toggle() abort
-  if vista#sidebar#IsVisible()
+  if vista#sidebar#IsOpen()
     call vista#sidebar#Close()
   else
     call vista#sidebar#Open()

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -114,3 +114,19 @@ function! vista#source#Update(bufnr, winnr, ...) abort
     let t:vista.source.fpath = a:2
   endif
 endfunction
+
+function! s:ApplyPeek(lnum, tag) abort
+  silent execute 'normal!' a:lnum.'z.'
+  let [_, start, _] = matchstrpos(getline('.'), a:tag)
+  call vista#util#Blink(1, 100, [a:lnum, start+1, strlen(a:tag)])
+endfunction
+
+if exists('*win_execute')
+  function! vista#source#PeekSymbol(lnum, tag) abort
+    call win_execute(bufwinid(t:vista.source.bufnr), 'noautocmd call s:ApplyPeek(a:lnum, a:tag)')
+  endfunction
+else
+  function! vista#source#PeekSymbol(lnum, tag) abort
+    call vista#WinExecute(t:vista.source.winnr(), function('s:ApplyPeek'), a:lnum, a:tag)
+  endfunction
+endif

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -127,6 +127,6 @@ if exists('*win_execute')
   endfunction
 else
   function! vista#source#PeekSymbol(lnum, tag) abort
-    call vista#WinExecute(t:vista.source.winnr(), function('s:ApplyPeek'), a:lnum, a:tag)
+    call vista#win#Execute(t:vista.source.winnr(), function('s:ApplyPeek'), a:lnum, a:tag)
   endfunction
 endif

--- a/autoload/vista/util.vim
+++ b/autoload/vista/util.vim
@@ -95,7 +95,7 @@ function! s:SafeSetBufline(bufnr, lines) abort
 endfunction
 
 function! vista#util#SetBufline(bufnr, lines) abort
-  call vista#WinExecute(t:vista.winnr(), function('s:SafeSetBufline'), a:bufnr, a:lines)
+  call vista#win#Execute(t:vista.winnr(), function('s:SafeSetBufline'), a:bufnr, a:lines)
 endfunction
 
 function! vista#util#Join(...) abort

--- a/autoload/vista/win.vim
+++ b/autoload/vista/win.vim
@@ -1,0 +1,49 @@
+
+let s:has_floating_win = exists('*nvim_open_win')
+let s:has_popup = exists('*popup_create')
+
+function! vista#win#CloseFloating() abort
+  if s:has_floating_win
+    call vista#floating#Close()
+  elseif s:has_popup
+    call vista#popup#Close()
+  endif
+endfunction
+
+function! vista#win#FloatingDisplay(...) abort
+  if s:has_popup
+    call call('vista#popup#DisplayAt', a:000)
+  elseif s:has_floating_win
+    call call('vista#floating#DisplayAt', a:000)
+  else
+    call vista#error#Need('neovim compiled with floating window support or vim compiled with popup feature')
+  endif
+endfunction
+
+" Show the folded content if in a closed fold.
+function! vista#win#ShowFoldedDetailInFloatingIsOk() abort
+  if foldclosed('.') != -1
+    if s:has_floating_win || s:has_popup
+      let foldclosed_end = foldclosedend('.')
+      let curlnum = line('.')
+      let lines = getbufline(t:vista.bufnr, curlnum, foldclosed_end)
+
+      if s:has_floating_win
+        call vista#floating#DisplayRawAt(curlnum, lines)
+      elseif s:has_popup
+        call vista#popup#DisplayRawAt(curlnum, lines)
+      endif
+
+      return v:true
+    endif
+  endif
+  return v:false
+endfunction
+
+function! vista#win#FloatingDisplayOrPeek(lnum, tag) abort
+  if s:has_floating_win || s:has_popup
+    call vista#win#FloatingDisplay(a:lnum, a:tag)
+  else
+    call vista#source#PeekSymbol(a:lnum, a:tag)
+  endif
+endfunction

--- a/autoload/vista/win.vim
+++ b/autoload/vista/win.vim
@@ -50,3 +50,23 @@ function! vista#win#FloatingDisplayOrPeek(lnum, tag) abort
     call vista#source#PeekSymbol(a:lnum, a:tag)
   endif
 endfunction
+
+" call Run in the window win unsilently, unlike win_execute() which uses
+" silent by default.
+"
+" CocAction only fetch symbols for current document, no way for specify the other at the moment.
+" workaround for #52
+"
+" see also #71
+function! vista#win#Execute(winnr, Run, ...) abort
+  if winnr() != a:winnr
+    noautocmd execute a:winnr.'wincmd w'
+    let l:switch_back = 1
+  endif
+
+  call call(a:Run, a:000)
+
+  if exists('l:switch_back')
+    noautocmd wincmd p
+  endif
+endfunction

--- a/autoload/vista/win.vim
+++ b/autoload/vista/win.vim
@@ -1,3 +1,6 @@
+" Copyright (c) 2019 Liu-Cheng Xu
+" MIT License
+" vim: ts=2 sw=2 sts=2 et
 
 let s:has_floating_win = exists('*nvim_open_win')
 let s:has_popup = exists('*popup_create')


### PR DESCRIPTION
- Split out the ctags and LSP logic in cursor.vim.
- Split out echo function into `echo.vim`.