### PR TITLE
Updated macOS brew command for universal-ctags

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ The JSON support for ctags is avaliable if u-ctags is linked to libjansson when 
 - macOS
 
     ```bash
-    $ brew install --with-jansson universal-ctags/universal-ctags/universal-ctags
+    $ brew tap universal-ctags/universal-ctags
+    $ brew install --with-jansson --HEAD universal-ctags/universal-ctags/universal-ctags
     ```
 
 - Ubuntu


### PR DESCRIPTION
brew will fail to tap with the `--with-jansson` flag because it doesn't know it's a flag before tapping, and this particular tap formula requires `--HEAD`:

```bash
$ brew install --with-jansson universal-ctags/universal-ctags/universal-ctags
...
Error: invalid option: --with-jansson
$ brew tap brew tap universal-ctags/universal-ctags
...
$  brew install --with-jansson universal-ctags/universal-ctags/universal-ctags
Error: universal-ctags/universal-ctags/universal-ctags is a head-only formula
Install with `brew install --HEAD universal-ctags/universal-ctags/universal-ctags`

$  brew install --with-jansson --HEAD universal-ctags/universal-ctags/universal-ctags
# Success!
```