### PR TITLE
Remove a unnecessary head space from finder rows when icon rendering is disabled

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -110,11 +110,16 @@ endfunction
 function! s:IntoRow(icon, kind, item) abort
   let line = t:vista.source.line_trimmed(a:item.lnum)
   let lnum_and_text = printf('%s:%s', a:item.lnum, a:item.text)
-  return printf('%s %s%s  [%s]%s  %s',
-        \ a:icon,
+  let row = printf('%s%s  [%s]%s  %s',
         \ lnum_and_text, repeat(' ', s:max_len_lnum_and_text- strwidth(lnum_and_text)),
         \ a:kind, repeat(' ', s:max_len_kind - strwidth(a:kind)),
         \ line)
+
+  if a:icon !=# ''
+    let row = printf('%s %s', a:icon, row)
+  endif
+
+  return row
 endfunction
 
 function! s:RenderGroupedData(grouped_data) abort


### PR DESCRIPTION
With current implementation, even though `g:vista#renderer#enable_icon` is set to `0`, a unnecessary space appears in head of each lines like below:

```
fzf:lcn>   < 83/83
>  47:Flag               [Method]     Flag(c int) bool
   44:Precision          [Method]     Precision() (prec int, ok bool)
   42:Width              [Method]     Width() (wid int, ok bool)
   40:Write              [Method]     Write(b []byte) (n int, err error)
   54:Format             [Method]     Format(f State, c rune)
   63:String             [Method]     String() string
   71:GoString           [Method]     GoString() string
...
```

So, this PR removes such a space from rows like below:

```
fzf:lcn>   < 83/83
> 47:Flag               [Method]     Flag(c int) bool
  44:Precision          [Method]     Precision() (prec int, ok bool)
  42:Width              [Method]     Width() (wid int, ok bool)
  40:Write              [Method]     Write(b []byte) (n int, err error)
  54:Format             [Method]     Format(f State, c rune)
  63:String             [Method]     String() string
  71:GoString           [Method]     GoString() string
...
```