### PR TITLE
Switch line number and tag in finder rows

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -86,7 +86,7 @@ function! s:GroupByKindForLSPData(lsp_items) abort
   for item in a:lsp_items
     let s:max_len_kind = max([s:max_len_kind, strwidth(item.kind)])
 
-    let lnum_and_text = printf('%s:%s', item.lnum, item.text)
+    let lnum_and_text = printf('%s:%s', item.text, item.lnum)
     let s:max_len_lnum_and_text = max([s:max_len_lnum_and_text, strwidth(lnum_and_text)])
 
     if has_key(s:grouped, item.kind)
@@ -102,14 +102,14 @@ function! s:FindColumnBoundary(grouped_data) abort
   for [kind, vals] in items(a:grouped_data)
     let s:max_len_kind = max([s:max_len_kind, strwidth(kind)])
 
-    let sub_max = max(map(copy(vals), 'strwidth(printf(''%s:%s'', v:val.lnum, v:val.text))'))
+    let sub_max = max(map(copy(vals), 'strwidth(printf(''%s:%s'', v:val.text, v:val.lnum))'))
     let s:max_len_lnum_and_text = max([s:max_len_lnum_and_text, sub_max])
   endfor
 endfunction
 
 function! s:IntoRow(icon, kind, item) abort
   let line = t:vista.source.line_trimmed(a:item.lnum)
-  let lnum_and_text = printf('%s:%s', a:item.lnum, a:item.text)
+  let lnum_and_text = printf('%s:%s', a:item.text, a:item.lnum)
   let row = printf('%s%s  [%s]%s  %s',
         \ lnum_and_text, repeat(' ', s:max_len_lnum_and_text- strwidth(lnum_and_text)),
         \ a:kind, repeat(' ', s:max_len_kind - strwidth(a:kind)),

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -66,13 +66,13 @@ function! vista#finder#fzf#extract(line) abort
   " matching tag can't contain whitespace, but a tag does have a chance to contain whitespace?
 
   if g:vista#renderer#enable_icon
-    let items = matchlist(icon_lnum_tag, '\(.*\) \(\d\+\):\([a-zA-Z:#_.,<>]*\)')
-    let lnum = items[2]
-    let tag = items[3]
-  else
-    let items = matchlist(icon_lnum_tag, '\(\d\+\):\([a-zA-Z:#_.,<>]*\)')
-    let lnum = items[1]
+    let items = matchlist(icon_lnum_tag, '\(.*\) \([a-zA-Z:#_.,<>]*\):\(\d\+\)')
     let tag = items[2]
+    let lnum = items[3]
+  else
+    let items = matchlist(icon_lnum_tag, '\([a-zA-Z:#_.,<>]*\):\(\d\+\)')
+    let tag = items[1]
+    let lnum = items[2]
   end
 
   return [lnum, tag]
@@ -156,10 +156,10 @@ function! vista#finder#fzf#Highlight() abort
     let idx += 1
   endfor
 
-  execute 'syntax match FZFVistaNumber /\s*\zs\d*\ze:\w/' 'contains=FZFVistaIcon,'.join(icon_groups, ',')
-  execute 'syntax match FZFVistaTag    /^[^\[]*\(\[\)\@=/' 'contains=FZFVistaNumber,FZFVistaIcon,'.join(icon_groups, ',')
-  syntax match FZFVistaScope  /^[^]]*]/ contains=FZFVistaTag,FZFVistaBracket
-  syntax match FZFVista /^[^│┌└]*/ contains=FZFVistaBracket,FZFVistaNumber,FZFVistaTag,FZFVistaScope
+  execute 'syntax match FZFVistaTag    /\s*.*\(:\d\)\@=/' 'contains=FZFVistaIcon,'.join(icon_groups, ',')
+  execute 'syntax match FZFVistaNumber /^[^\[]*\(\[\)\@=/' 'contains=FZFVistaTag,FZFVistaIcon,'.join(icon_groups, ',')
+  syntax match FZFVistaScope  /^[^]]*]/ contains=FZFVistaNumber,FZFVistaBracket
+  syntax match FZFVista /^[^│┌└]*/ contains=FZFVistaBracket,FZFVistaTag,FZFVistaNumber,FZFVistaScope
   syntax match FZFVistaBracket /\[\|\]/ contained
 
   hi default link FZFVistaBracket  SpecialKey


### PR DESCRIPTION
Switch positions of line number and tag in finder rows like below:

### Before

![image](https://user-images.githubusercontent.com/2134196/73748938-c04e0e80-479d-11ea-8144-94a8d4d75539.png)

### After

![image](https://user-images.githubusercontent.com/2134196/73749020-dfe53700-479d-11ea-9866-20030ccd7271.png)

In the normal vista window, tags place before line numbers like below. I think finder's columns order should be same as the window. Furthermore, tags which I think we might be most interested in will be aligned by this change like `After` image.

![image](https://user-images.githubusercontent.com/2134196/73749114-115e0280-479e-11ea-9162-74708cddb26a.png)

Does this make sense?