### PR TITLE
Make FZFVistaBracket more correctly

### DIFF
--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -157,10 +157,10 @@ function! vista#finder#fzf#Highlight() abort
   endfor
 
   execute 'syntax match FZFVistaTag    /\s*.*\(:\d\)\@=/' 'contains=FZFVistaIcon,'.join(icon_groups, ',')
-  execute 'syntax match FZFVistaNumber /^[^\[]*\(\[\)\@=/' 'contains=FZFVistaTag,FZFVistaIcon,'.join(icon_groups, ',')
+  execute 'syntax match FZFVistaNumber /^[^\[]*\(\s\s\[\)\@=/' 'contains=FZFVistaTag,FZFVistaIcon,'.join(icon_groups, ',')
   syntax match FZFVistaScope  /^[^]]*]/ contains=FZFVistaNumber,FZFVistaBracket
   syntax match FZFVista /^[^│┌└]*/ contains=FZFVistaBracket,FZFVistaTag,FZFVistaNumber,FZFVistaScope
-  syntax match FZFVistaBracket /\[\|\]/ contained
+  syntax match FZFVistaBracket /\s\s\[\|\]\s\s/ contained
 
   hi default link FZFVistaBracket  SpecialKey
   hi default link FZFVistaNumber   Number


### PR DESCRIPTION
With current implementation, `FZFVistaBracket` affects undesired brackets like below: (pay attention to `[]` before `byte`)

![image](https://user-images.githubusercontent.com/2134196/73753624-571ec900-47a6-11ea-8439-140b2790321a.png)

This PR make `FZFVistaBracket` more correctly like below:

![image](https://user-images.githubusercontent.com/2134196/73753552-3ce4eb00-47a6-11ea-856b-f226e6a72ea0.png)

Even though this is still not perfect, I think this highlight rules can cover in most cases.