### PR TITLE
Change ctags renderer format

### DIFF
--- a/autoload/vista/renderer/default.vim
+++ b/autoload/vista/renderer/default.vim
@@ -22,16 +22,17 @@ function! s:Assemble(line, depth) abort
 
   let kind = get(line, 'kind', '')
 
-  if !empty(kind)
-    let kind = vista#renderer#Decorate(kind)
-  endif
+  " if !empty(kind)
+    " let kind = vista#renderer#Decorate(kind)
+  " endif
 
   let row = vista#util#Join(
         \ repeat(' ', a:depth * 4),
         \ s:GetVisibility(line),
+        \ vista#renderer#IconFor(kind).' ',
         \ get(line, 'name'),
         \ get(line, 'signature', ''),
-        \ ' : '.kind,
+        \ ' '.kind,
         \ ':'.get(line, 'line', '')
         \ )
 

--- a/autoload/vista/renderer/default.vim
+++ b/autoload/vista/renderer/default.vim
@@ -22,10 +22,6 @@ function! s:Assemble(line, depth) abort
 
   let kind = get(line, 'kind', '')
 
-  " if !empty(kind)
-    " let kind = vista#renderer#Decorate(kind)
-  " endif
-
   let row = vista#util#Join(
         \ repeat(' ', a:depth * 4),
         \ s:GetVisibility(line),

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -14,10 +14,10 @@ syntax match VistaProtected /^\s*\~\</ contained
 syntax match VistaPrivate /^\s*-\</ contained
 
 syntax match VistaParenthesis /(\|)/ contained
-syntax match VistaArgs  /(\zs.*\ze)/
+syntax match VistaArgs  /(\zs.*\ze) /
 syntax match VistaColon /:\ze\d\+$/ contained
 syntax match VistaLineNr /\d\+$/
-syntax match VistaKind / \a*:\d*$/ contains=VistaColon,VistaLineNr
+syntax match VistaKind / \a*\ze:\d\+$/ contained
 syntax match VistaScopeKind /\S\+\zs \a\+\ze:\d\+$/ contains=VistaArgs,VistaColon,VistaLineNr
 syntax match VistaScope /^\S.*$/ contains=VistaPrivate,VistaProtected,VistaPublic,VistaKind,VistaIcon,VistaParenthesis
 syntax region VistaTag start="^" end="$" contains=VistaPublic,VistaProtected,VistaPrivate,VistaArgs,VistaScope,VistaScopeKind,VistaLineNr,VistaColon,VistaIcon

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -20,7 +20,7 @@ syntax match VistaLineNr /\d\+$/
 syntax match VistaKind / \a*:\d*$/ contains=VistaColon,VistaLineNr
 syntax match VistaScopeKind / \a\+\ze:\d\+$/ contains=VistaArgs,VistaColon,VistaLineNr
 syntax match VistaScope /^\S.*$/ contains=VistaPrivate,VistaProtected,VistaPublic,VistaKind,VistaIcon,VistaParenthesis
-syntax region VistaTag start="^" end="$" contains=VistaPublic,VistaProtected,VistaPrivate,VistaArgs,VistaScope,VistaScopeKind,VistaLineNr,VistaColon
+syntax region VistaTag start="^" end="$" contains=VistaPublic,VistaProtected,VistaPrivate,VistaArgs,VistaScope,VistaScopeKind,VistaLineNr,VistaColon,VistaIcon
 
 hi default link VistaParenthesis Operator
 hi default link VistaScope       Function

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -18,7 +18,7 @@ syntax match VistaArgs  /(\zs.*\ze)/
 syntax match VistaColon /:\ze\d\+$/ contained
 syntax match VistaLineNr /\d\+$/
 syntax match VistaKind / \a*:\d*$/ contains=VistaColon,VistaLineNr
-syntax match VistaScopeKind /: .*$/ contains=VistaArgs,VistaColon,VistaLineNr
+syntax match VistaScopeKind / \a\+\ze:\d\+$/ contains=VistaArgs,VistaColon,VistaLineNr
 syntax match VistaScope /^\S.*$/ contains=VistaPrivate,VistaProtected,VistaPublic,VistaKind,VistaIcon,VistaParenthesis
 syntax region VistaTag start="^" end="$" contains=VistaPublic,VistaProtected,VistaPrivate,VistaArgs,VistaScope,VistaScopeKind,VistaLineNr,VistaColon
 

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -15,10 +15,10 @@ syntax match VistaPrivate /^\s*-\</ contained
 
 syntax match VistaParenthesis /(\|)/ contained
 syntax match VistaArgs  /(\zs.*\ze) /
-syntax match VistaColon /:\ze\d\+$/ contained
-syntax match VistaLineNr /\d\+$/
 syntax match VistaKind / \a*\ze:\d\+$/ contained
-syntax match VistaScopeKind /\S\+\zs \a\+\ze:\d\+$/ contains=VistaArgs,VistaColon,VistaLineNr
+syntax match VistaScopeKind /\S\+\zs \a\+\ze:\d\+$/ nextgroup=VistaColon
+syntax match VistaColon /:\ze\d\+$/ contained nextgroup=VistaLineNr
+syntax match VistaLineNr /\d\+$/
 syntax match VistaScope /^\S.*$/ contains=VistaPrivate,VistaProtected,VistaPublic,VistaKind,VistaIcon,VistaParenthesis
 syntax region VistaTag start="^" end="$" contains=VistaPublic,VistaProtected,VistaPrivate,VistaArgs,VistaScope,VistaScopeKind,VistaLineNr,VistaColon,VistaIcon
 

--- a/syntax/vista.vim
+++ b/syntax/vista.vim
@@ -18,7 +18,7 @@ syntax match VistaArgs  /(\zs.*\ze)/
 syntax match VistaColon /:\ze\d\+$/ contained
 syntax match VistaLineNr /\d\+$/
 syntax match VistaKind / \a*:\d*$/ contains=VistaColon,VistaLineNr
-syntax match VistaScopeKind / \a\+\ze:\d\+$/ contains=VistaArgs,VistaColon,VistaLineNr
+syntax match VistaScopeKind /\S\+\zs \a\+\ze:\d\+$/ contains=VistaArgs,VistaColon,VistaLineNr
 syntax match VistaScope /^\S.*$/ contains=VistaPrivate,VistaProtected,VistaPublic,VistaKind,VistaIcon,VistaParenthesis
 syntax region VistaTag start="^" end="$" contains=VistaPublic,VistaProtected,VistaPrivate,VistaArgs,VistaScope,VistaScopeKind,VistaLineNr,VistaColon,VistaIcon
 


### PR DESCRIPTION
Show the icon at the beginning as what most other tools do, e.g., IDEA>Structures.

Before:

<img width="709" alt="截屏2020-02-13上午11 17 25" src="https://user-images.githubusercontent.com/8850248/74398399-770f5600-4e52-11ea-9272-196ef990a26a.png">

Now:
<img width="708" alt="截屏2020-02-13上午11 15 52" src="https://user-images.githubusercontent.com/8850248/74398337-3c0d2280-4e52-11ea-9879-4a2cdfb89cfa.png">
