### PR TITLE
Fix echo error in cmdline when the tag name contain "~".

### DIFF
--- a/autoload/vista/echo.vim
+++ b/autoload/vista/echo.vim
@@ -70,7 +70,7 @@ function! vista#echo#EchoInCmdline(msg, tag) abort
 
   " Case II:\@ $R^2 \geq Q^3$ :  paragraph:175
   try
-    let [_, start, end] = matchstrpos(msg, '\C'.tag)
+    let start = stridx(msg, tag)
 
     " If couldn't find the tag in the msg
     if start == -1
@@ -92,6 +92,7 @@ function! vista#echo#EchoInCmdline(msg, tag) abort
     echohl Statement | echon msg[0 : start-1] | echohl NONE
   endif
 
+  let end = start + strlen(tag)
   echohl Search    | echon msg[start : end-1] | echohl NONE
   echohl Statement | echon msg[end : ]        | echohl NONE
 endfunction

--- a/autoload/vista/highlight.vim
+++ b/autoload/vista/highlight.vim
@@ -24,9 +24,8 @@ function! vista#highlight#Add(lnum, ensure_visible, tag) abort
     " If we know the tag, then what we have to do is to use the length of tag
     " based on the starting point.
     "
-    " start is 0-based, while the column used in stridx or matchstrpos is 1-based.
+    " start is 0-based, while the column used in matchstrpos is 1-based.
     if !empty(a:tag)
-      let start = stridx(cur_line, a:tag)
       let hi_pos = [a:lnum, start+1, strlen(a:tag)]
     else
       let [_, end, _] = matchstrpos(cur_line, ':\d\+$')

--- a/autoload/vista/highlight.vim
+++ b/autoload/vista/highlight.vim
@@ -24,8 +24,9 @@ function! vista#highlight#Add(lnum, ensure_visible, tag) abort
     " If we know the tag, then what we have to do is to use the length of tag
     " based on the starting point.
     "
-    " start is 0-based, while the column used in matchstrpos is 1-based.
+    " start is 0-based, while the column used in stridx or matchstrpos is 1-based.
     if !empty(a:tag)
+      let start = stridx(cur_line, a:tag)
       let hi_pos = [a:lnum, start+1, strlen(a:tag)]
     else
       let [_, end, _] = matchstrpos(cur_line, ':\d\+$')


### PR DESCRIPTION
More safely and accurately to find the starting position of the accurate
tag. Avoid pattern matching, as the tag name may contain "~".

I found this bug when I use vista.vim to browse a qt project.
The destructor of the qt class is indicated by adding `~` in front of the corresponding constructor.

error:
![屏幕快照 2020-02-25 13 58 18](https://user-images.githubusercontent.com/25200758/75219536-ff3d1600-57d7-11ea-8519-a19b7988d513.png)

fix:
![屏幕快照 2020-02-25 14 03 59](https://user-images.githubusercontent.com/25200758/75219590-27c51000-57d8-11ea-8262-5204e8947c78.png)
