### PR TITLE
 Fix bug with passing too many arguments to function when running finder on entire project

### DIFF
--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -138,6 +138,7 @@ function! s:ProjectRun(...) abort
   call s:ApplyRun()
   if has('nvim')
     call vista#finder#fzf#Highlight()
+  endif
 endfunction
 
 function! vista#finder#fzf#Highlight() abort

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -129,13 +129,13 @@ endfunction
 function! s:ProjectRun(...) abort
   let source = s:aligner.project_ctags()
   let prompt = (get(s:, 'using_alternative', v:false) ? '*' : '').s:cur_executive.'> '
-  let opts = {
+  let s:opts = {
           \ 'source': source,
           \ 'sink': function('s:project_sink'),
           \ 'options': ['--prompt', prompt] + get(g:, 'vista_fzf_opt', []),
           \ }
 
-  call s:ApplyRun(opts, 'vista#finder#fzf#Highlight')
+  call s:ApplyRun()
 endfunction
 
 function! vista#finder#fzf#Highlight() abort

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -136,6 +136,8 @@ function! s:ProjectRun(...) abort
           \ }
 
   call s:ApplyRun()
+  if has('nvim')
+    call vista#finder#fzf#Highlight()
 endfunction
 
 function! vista#finder#fzf#Highlight() abort


### PR DESCRIPTION
Running `finder` on the entire project (i.e. using `:Vista finder!`) doesn't currently work because too many arguments are being passed to `s:ApplyRun`. I've made some minor changes to fix this and still keep highlighting. 

PS. Is there a way to enable preview for `finder` with project-wide tags?