### PR TITLE
Ignore ctags warning lines

### DIFF
--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -84,14 +84,14 @@ function! s:BuildCmd(origin_fpath) abort
   let custom_cmd = s:GetCustomCmd(&filetype)
 
   if custom_cmd isnot v:null
-    let cmd = printf('%s %s', custom_cmd, s:tmp_file)
+    let cmd = printf('%s %s 2>/dev/null', custom_cmd, s:tmp_file)
     if stridx(custom_cmd, '--output-format=json') > -1
       let s:TagParser = function('vista#parser#ctags#FromJSON')
     else
       let s:TagParser = function('vista#parser#ctags#FromExtendedRaw')
     endif
   else
-    let cmd = s:GetDefaultCmd(s:tmp_file)
+    let cmd = s:GetDefaultCmd(s:tmp_file) . ' 2>/dev/null'
     let s:TagParser = s:DefaultTagParser
   endif
 

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -103,6 +103,9 @@ function! vista#parser#ctags#FromExtendedRaw(line, container) abort
   if a:line =~# '^!_TAG'
     return
   endif
+  if a:line =~# '^ctags: Warning:'
+    return
+  endif
   let items = split(a:line, '\t')
 
   let line = {}

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -103,9 +103,6 @@ function! vista#parser#ctags#FromExtendedRaw(line, container) abort
   if a:line =~# '^!_TAG'
     return
   endif
-  if a:line =~# '^ctags: Warning:'
-    return
-  endif
   let items = split(a:line, '\t')
 
   let line = {}


### PR DESCRIPTION
Universal ctags sometimes produces warning lines (in stderr) which make vista.vim trip.

```
$ ctags -f- src/components/JSONSchemaModal.js                                                                                                                         master 
ctags: Warning: ignoring null tag in src/components/JSONSchemaModal.js(line: 117)
CheckboxWidget	src/components/JSONSchemaModal.js	/^  CheckboxWidget: (props) => ($/;"	M
CheckboxWidget	src/components/JSONSchemaModal.js	/^  CheckboxWidget: (props) => ($/;"	p	class:widgets
...
```