### PR TITLE
Fix FZF Preview (no win32)

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -153,8 +153,10 @@ function! vista#finder#PrepareOpts(source, prompt) abort
           \ }
 
   if exists('g:vista_fzf_preview')
+    let object_name_index = g:vista#renderer#enable_icon ? '2' : '1'
+    let extract_line_number = ':$(echo {' . object_name_index . "} | grep -o '[^:]*$')"
     let preview_opts = call('fzf#vim#with_preview', g:vista_fzf_preview).options
-    let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . (g:vista#renderer#enable_icon ? ':{2}' : ':{1}')
+    let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . extract_line_number
     call extend(opts.options, preview_opts)
   endif
 

--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -153,10 +153,17 @@ function! vista#finder#PrepareOpts(source, prompt) abort
           \ }
 
   if exists('g:vista_fzf_preview')
-    let object_name_index = g:vista#renderer#enable_icon ? '2' : '1'
-    let extract_line_number = ':$(echo {' . object_name_index . "} | grep -o '[^:]*$')"
     let preview_opts = call('fzf#vim#with_preview', g:vista_fzf_preview).options
-    let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . extract_line_number
+
+    if has('win32')
+      " keeping old code around since we are not sure if / how preview works on windows
+      let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . (g:vista#renderer#enable_icon ? ':{2}' : ':{1}')
+    else
+      let object_name_index = g:vista#renderer#enable_icon ? '2' : '1'
+      let extract_line_number = ':$(echo {' . object_name_index . "} | grep -o '[^:]*$')"
+      let preview_opts[-1] = preview_opts[-1][0:-3] . t:vista.source.fpath . extract_line_number
+    endif
+
     call extend(opts.options, preview_opts)
   endif
 


### PR DESCRIPTION
**Note**: same as #248 but excludes the fix from Win32 as per [this request](https://github.com/liuchengxu/vista.vim/pull/248#issuecomment-597992430)

The FZF Preview has been broken ever since #231 when the positions of object/function name and line number were switched. This PR uses grep to grab the line number only and pass it to fzf preview.sh in the format it expects.

See https://github.com/liuchengxu/vista.vim/pull/231#issuecomment-595985345 for more details

### Before:
![image](https://user-images.githubusercontent.com/551858/76140140-f260c380-601c-11ea-8c9d-e1b290f34f00.png)

### After:
![Firefox 2020-03-07 at 02 40 44](https://user-images.githubusercontent.com/551858/76140150-0f959200-601d-11ea-9460-6dc6ac858524.png)
