### PR TITLE
vista#parser#ctags#FromExtendedRaw: Return on unparsable ctags output

### DIFF
--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -95,8 +95,10 @@ function! vista#parser#ctags#FromExtendedRaw(line, container) abort
   if a:line =~# '^!_TAG'
     return
   endif
-  " Prevent bugs when a:line is all whitespace
-  if a:line =~# '^\s*$'
+  " Prevent bugs when a:line is all whitespace or doesn't contain any tabs
+  " (can't be parsed).
+  if a:line =~# '^\s*$' || stridx(a:line, '\t') == -1
+    echom "Vista.vim: Error parsing ctags output: '" . a:line . "'"
     return
   endif
 

--- a/autoload/vista/parser/ctags.vim
+++ b/autoload/vista/parser/ctags.vim
@@ -98,7 +98,8 @@ function! vista#parser#ctags#FromExtendedRaw(line, container) abort
   " Prevent bugs when a:line is all whitespace or doesn't contain any tabs
   " (can't be parsed).
   if a:line =~# '^\s*$' || stridx(a:line, '\t') == -1
-    echom "Vista.vim: Error parsing ctags output: '" . a:line . "'"
+    " Useful for debugging
+    " echom "Vista.vim: Error parsing ctags output: '" . a:line . "'"
     return
   endif
 


### PR DESCRIPTION
Errors from ctags had no tabs in them, so splitting them didn't give
enough indexes. Now, if no tabs or all whitespace, just return

Also add an error message if ctags output parsing fails.