### PR TITLE
Highlight nearest tag for coc renderer

### DIFF
--- a/autoload/vista/executive/coc.vim
+++ b/autoload/vista/executive/coc.vim
@@ -15,6 +15,8 @@ function! s:Extract(symbols) abort
     return
   endif
 
+  let g:vista.functions = []
+  let g:vista.raw = []
   call map(a:symbols, 'vista#parser#lsp#CocSymbols(v:val, s:data)')
 
   if !empty(s:data)

--- a/autoload/vista/parser/lsp.vim
+++ b/autoload/vista/parser/lsp.vim
@@ -82,6 +82,13 @@ function! vista#parser#lsp#CocSymbols(symbol, container) abort
     return
   endif
 
+  let raw = { 'line': a:symbol.lnum, 'kind': a:symbol.kind, 'name': a:symbol.text }
+  call add(g:vista.raw, raw)
+
+  if a:symbol.kind ==? 'Method' || a:symbol.kind ==? 'Function'
+    call add(g:vista.functions, a:symbol)
+  endif
+
   call add(a:container, {
         \ 'lnum': a:symbol.lnum,
         \ 'col': a:symbol.col,


### PR DESCRIPTION
Previously, if I had the `:Vista coc` pane open but my cursor was in the code
window, no tag would be highlighted in the vista pane. The `:Vista ctags` pane
would correctly highlight the nearest tag from where my cursor was in the code.

I discovered that this was because the global variables `g:vista.functions` and
`g:vista.raw` are not set when using the coc executive.

This change populates those two globals from list of symbols in the response
from coc. Similar to what happens with the ctags renderer, the `vlnum` values in
`g:vista.raw` are later filled in during rendering the vista window contents.

Working nearest tag highlighting for `:Vista coc`:

[![asciicast](https://asciinema.org/a/TBtsLYsmYx6dEqvKS6kcUZSAl.svg)](https://asciinema.org/a/TBtsLYsmYx6dEqvKS6kcUZSAl)