### PR TITLE
Add line between coc leveled tags and tags by kind

### DIFF
--- a/autoload/vista/renderer/hir/lsp.vim
+++ b/autoload/vista/renderer/hir/lsp.vim
@@ -45,6 +45,10 @@ function! s:RenderLSPHirAndThenGroupByKind(data) abort
     let idx += 1
   endfor
 
+  if len(level0) > 0
+    call add(rendered, '')
+  endif
+
   for [kind, vs] in items(level0)
     call add(rendered, vista#renderer#Decorate(kind))
     call map(vs, 'add(rendered, s:IntoLSPNonHirRow(v:val))')


### PR DESCRIPTION
Since all other groups are spaced out with an empty line, it looked wrong that
there was no empty line between the hierarchical tag groups and the tags grouped
by kind.

Before:
![Screenshot from 2020-04-18 23-26-52](https://user-images.githubusercontent.com/1505923/79678706-3f16ed00-81cc-11ea-8528-c06cf9f8b805.png)

After:
![Screenshot from 2020-04-18 23-24-53](https://user-images.githubusercontent.com/1505923/79678710-43430a80-81cc-11ea-8d6e-201e6b266fcd.png)