### PR TITLE
Add show detail support for nvim_lsp provider

### DIFF
--- a/autoload/vista/cursor/lsp.vim
+++ b/autoload/vista/cursor/lsp.vim
@@ -9,6 +9,8 @@ function! s:GetInfoFromLSPAndExtension() abort
   if g:vista.provider ==# 'coc'
     let tag = vista#util#Trim(raw_cur_line[:stridx(raw_cur_line, ':')-1])
     return tag
+  elseif g:vista.provider ==# 'nvim_lsp'
+    return substitute(raw_cur_line, '\v.*\s(.*):.*', '\1', '')
   elseif g:vista.provider ==# 'markdown' || g:vista.provider ==# 'rst'
     if line('.') < 3
       return v:null


### PR DESCRIPTION
No matter which echo strategy the user choose, as soon as the `nvim_lsp` strategy is in use it does not work to show details of the current tag under cursor. This is due to a missing implementation to extract the tag of the current Vista buffer line for the `nvim_lsp` provider. Such has been added. As result the user can now use the `p` mapping within the Vista window, as well as the `g:vista_echo_cursor` option.