### PR TITLE
More strict regex for FZFVistaTag and FZFVistaScope to prevent the preview codes from being highlighted

### DIFF
--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -161,9 +161,9 @@ function! vista#finder#fzf#Highlight() abort
     let idx += 1
   endfor
 
-  execute 'syntax match FZFVistaTag    /\s*.*\(:\d\)\@=/' 'contains=FZFVistaIcon,'.join(icon_groups, ',')
+  execute 'syntax match FZFVistaTag    /\s*.*\(:\d\+\s\)\@=/' 'contains=FZFVistaIcon,'.join(icon_groups, ',')
   execute 'syntax match FZFVistaNumber /^[^\[]*\(\s\s\[\)\@=/' 'contains=FZFVistaTag,FZFVistaIcon,'.join(icon_groups, ',')
-  syntax match FZFVistaScope  /^[^]]*]/ contains=FZFVistaNumber,FZFVistaBracket
+  syntax match FZFVistaScope  /^[^]│]*]/ contains=FZFVistaNumber,FZFVistaBracket
   syntax match FZFVista /^[^│┌└]*/ contains=FZFVistaBracket,FZFVistaTag,FZFVistaNumber,FZFVistaScope
   syntax match FZFVistaBracket /\s\s\[\|\]\s\s/ contained
 


### PR DESCRIPTION
When there is a [:num] structure in codes (which is common in python), FZFVistaTag highlight group will be mismatched. This pr includes a more strict regex to fix it.
Another problem is that FZFVistaScope highlight group will highlight codes in the fzf preview window, I also slightly modified the regex to fix it.
Some examples can be found in [#264](https://github.com/liuchengxu/vista.vim/issues/264).
Thank you!