### PR TITLE
Don't use obsolete ctags option --file-scope

### DIFF
--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -36,7 +36,7 @@ endfunction
 
 function! s:GetDefaultCmd(file) abort
   " Refer to tagbar
-  let common_opt = '--format=2 --excmd=pattern --fields=nksSaf --file-scope=yes --sort=no --append=no'
+  let common_opt = '--format=2 --excmd=pattern --fields=nksSaf --extras=+F --sort=no --append=no'
 
   " Do not pass --extras for C/CPP in order to let uctags handle the tags for anonymous
   " entities correctly.


### PR DESCRIPTION
- As of ctags commit `cf82cfa2` --file-scope is obsolete.
- use `--extras=+F` instead.