### PR TITLE
Support API Blueprint for TOC rendering

### DIFF
--- a/autoload/vista/toc.vim
+++ b/autoload/vista/toc.vim
@@ -4,7 +4,8 @@
 
 " vimwiki supports the standard markdown syntax.
 " pandoc supports the basic markdown format.
-let s:toc_supported = ['markdown', 'rst', 'vimwiki', 'pandoc']
+" API Blueprint is a set of semantic assumptions on top of markdown.
+let s:toc_supported = ['markdown', 'rst', 'vimwiki', 'pandoc', 'apiblueprint']
 
 function! vista#toc#IsSupported(filetype) abort
   return index(s:toc_supported, a:filetype) > -1


### PR DESCRIPTION
[API Blueprint](https://apiblueprint.org/documentation/specification.html) is a set of semantic assumptions on top of markdown, so the TOC mechanism can render this without an issue.

With this small change, when installing [apiblueprint.vim](https://github.com/kylef/apiblueprint.vim) and configuring vista.vim as following, the table of contents is rendered correctly:
```viml
let g:vista_executive_for = {
    \ 'apiblueprint': 'markdown',
\ }

```