### PR TITLE
fix #304

### DIFF
--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -16,7 +16,12 @@ endfunction
 
 function! s:NewWindow() abort
   let open = g:vista_sidebar_position.' '.g:vista_sidebar_width.'new'
-  silent execute open '__vista__'
+
+  if get(g:, 'vista_sidebar_keepalt', 0) == 0
+    silent execute open '__vista__'
+  else
+    silent execute 'keepalt '.open '__vista__'
+  endif
 
   execute 'setlocal filetype='.vista#sidebar#WhichFileType()
 

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -17,10 +17,10 @@ endfunction
 function! s:NewWindow() abort
   let open = g:vista_sidebar_position.' '.g:vista_sidebar_width.'new'
 
-  if get(g:, 'vista_sidebar_keepalt', 0) == 0
-    silent execute open '__vista__'
-  else
+  if get(g:, 'vista_sidebar_keepalt', 0)
     silent execute 'keepalt '.open '__vista__'
+  else
+    silent execute open '__vista__'
   endif
 
   execute 'setlocal filetype='.vista#sidebar#WhichFileType()

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -177,6 +177,14 @@ g:vista_sidebar_width                                      *g:vista_sidebar_widt
 
   Width of vista sidebar.
 
+g:vista_sidebar_keepalt                                  *g:vista_sidebar_keepalt*
+
+  Type: |Number|
+  Default: `0`
+
+  Set this option to `1` to keep the alternate buffer when opening vista
+  sidebar. See `:h keepalt` for more information.
+
 g:vista_fold_toggle_icons                              *g:vista_fold_toggle_icons*
 
   Type: |List|


### PR DESCRIPTION
1. add g:vista_sidebar_keepalt option to determine whether or not to
   keep the alternate buffer when opening vista sidebar
2. add corresponding doc