### PR TITLE
Escape spaces in file path when running fzf.vim preview

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -171,7 +171,7 @@ function! vista#finder#PrepareOpts(source, prompt) abort
     else
       let object_name_index = g:vista#renderer#enable_icon ? '2' : '1'
       let extract_line_number = ':$(echo {' . object_name_index . "} | grep -o '[^:]*$')"
-      let preview_opts[-1] = preview_opts[-1][0:-3] . g:vista.source.fpath . extract_line_number
+      let preview_opts[-1] = preview_opts[-1][0:-3] . fnameescape(g:vista.source.fpath) . extract_line_number
     endif
 
     call extend(opts.options, preview_opts)


### PR DESCRIPTION
Add fnameescape() to the g:vista.source.fpath, so that the fzf.vim preview function correctly for files with paths containing spaces. Fix issue #307 
Screenshot of preview:
![Screenshot 2020-06-19 at 12 29 56 PM](https://user-images.githubusercontent.com/45414421/85097030-c31b3e80-b228-11ea-9446-45a2517105f8.png)
Screenshot of file path (in statusline):
![Screenshot 2020-06-19 at 12 30 07 PM](https://user-images.githubusercontent.com/45414421/85097039-ce6e6a00-b228-11ea-8a2d-2fdec8d87f08.png)
