### PR TITLE
Always close popups before opening and unlet winid

### DIFF
--- a/autoload/vista/popup.vim
+++ b/autoload/vista/popup.vim
@@ -9,6 +9,9 @@ let s:popup_delay = get(g:, 'vista_floating_delay', 100)
 function! s:ClosePopup() abort
   if exists('s:popup_winid')
     call popup_hide(s:popup_winid)
+    try
+      unlet s:popup_winid
+    catch | endtry
     autocmd! VistaPopup
   endif
   let g:vista.popup_visible = v:false
@@ -124,6 +127,7 @@ function! s:DispatchDisplayer(Displayer, lnum, tag_or_raw_lines) abort
 endfunction
 
 function! vista#popup#DisplayAt(lnum, tag) abort
+  call s:ClosePopup()
   call s:DispatchDisplayer(function('s:DisplayAt'), a:lnum, a:tag)
 endfunction
 


### PR DESCRIPTION
This fixes #149 which I am also experiencing, despite not using coc.

I cleared out my config until I was able to identify ALE as the culprit - my stripped down config would leave vista popups open when ALE was removed, but would close them with ALE was present.

However, after adding back other plugins but _removing_ ALE, the popups began closing again. Rather than continuing to track down plugins that may cause the issue, I've come to the conclusion that some relatively generic Vim autocmd functionality is causing the `CursorMoved` autocmd to fire and it is difficult to avoid that.

Instead, this workaround simply closes the popup before any attempt to open it, and also unlets the `s:popupid` variable, ensuring that the popup is always recreated.