### PR TITLE
Change nvim-lsp to nvim-lspconfig and change link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In addition to being a tags viewer, vista.vim can also be a symbol navigator sim
     - [x] [coc.nvim](https://github.com/neoclide/coc.nvim)
     - [x] [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
     - [x] [vim-lsc](https://github.com/natebosch/vim-lsc)
-    - [x] [nvim-lsp](https://github.com/neovim/neovim)
+    - [x] [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
 - [x] Finder for tags and LSP symbols.
     - [x] [fzf](https://github.com/junegunn/fzf)
     - [x] [skim](https://github.com/lotabout/skim)


### PR DESCRIPTION
nvim-lsp was renamed to nvim-lspconfig and previously the link was pointing to nvim rather than nvim-lspconfig.