### PR TITLE
Add configuration option for floating highlight

### DIFF
--- a/autoload/vista/floating.vim
+++ b/autoload/vista/floating.vim
@@ -6,6 +6,7 @@ let s:floating_timer = -1
 let s:last_lnum = -1
 
 let s:floating_delay = get(g:, 'vista_floating_delay', 100)
+let s:floating_highlight = get(g:, 'vista_floating_highlight', 'PMenu')
 
 " Vista sidebar window usually sits at the right side.
 " TODO improve me!
@@ -152,8 +153,10 @@ function! s:Display(msg, win_id) abort
   call s:HighlightTagInFloatinWin()
 
   let &l:filetype = getbufvar(g:vista.source.bufnr, '&ft')
+
+  call setwinvar(s:floating_win_id, '&winhl', 'Normal:'.s:floating_highlight)
+
   setlocal
-        \ winhl=Normal:Pmenu
         \ buftype=nofile
         \ nobuflisted
         \ bufhidden=hide

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -225,6 +225,13 @@ g:vista_echo_cursor_strategy                        *g:vista_echo_cursor_strateg
   `both`         - both `echo` and `floating_win` if it's avaliable otherwise
                  `scroll` will be used.
 
+g:vista_floating_highlight                    *g:vista_floating_highlight*
+
+  Type: |String|
+  Default: `Pmenu`
+
+  Update the highlighting for the floating window.
+
 g:vista_update_on_text_changed                    *g:vista_update_on_text_changed*
 
   Type: |Number|


### PR DESCRIPTION
I added a setting to allow the user to override the default highlighting for preview windows. I didn't like the default of `Pmenu` and it looks like [nvim](https://neovim.io/doc/user/syntax.html) and [coc](https://github.com/neoclide/coc.nvim/blob/release/autoload/coc/float.vim#L77) allow users to override the highlighting here so why not vista!

**Example:**

```
let g:vista_floating_highlight = 'VistaFloat'
highlight link VistaFloat NormalFloat
```
