### PR TITLE
fzf: render preview window when it's needed

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -164,30 +164,32 @@ function! vista#finder#PrepareOpts(source, prompt) abort
           \ 'options': ['--prompt', a:prompt] + get(g:, 'vista_fzf_opt', []),
           \ }
 
-  let idx = 0
-  let opt_preview_window_processed = v:false
-  while idx < len(g:vista_fzf_preview)
-    if g:vista_fzf_preview[idx] =~# '^\(left\|up\|right\|down\)'
-      let g:vista_fzf_preview[idx] = g:vista_fzf_preview[idx] . ':+{-1}-5'
-      let opt_preview_window_processed = v:true
+  if len(g:vista_fzf_preview) > 0
+    let idx = 0
+    let opt_preview_window_processed = v:false
+    while idx < len(g:vista_fzf_preview)
+      if g:vista_fzf_preview[idx] =~# '^\(left\|up\|right\|down\)'
+        let g:vista_fzf_preview[idx] = g:vista_fzf_preview[idx] . ':+{-1}-5'
+        let opt_preview_window_processed = v:true
+      endif
+      let idx = idx + 1
+    endwhile
+    if !opt_preview_window_processed
+      call extend(g:vista_fzf_preview, ['right:+{-1}-5'])
     endif
-    let idx = idx + 1
-  endwhile
-  if !opt_preview_window_processed
-    call extend(g:vista_fzf_preview, ['right:+{-1}-5'])
-  endif
-  let preview_opts = call('fzf#vim#with_preview', g:vista_fzf_preview).options
+    let preview_opts = call('fzf#vim#with_preview', g:vista_fzf_preview).options
 
-  if has('win32')
-    " keeping old code around since we are not sure if / how preview works on windows
-    let preview_opts[-1] = preview_opts[-1][0:-3] . g:vista.source.fpath . (g:vista#renderer#enable_icon ? ':{2}' : ':{1}')
-  else
-    let object_name_index = g:vista#renderer#enable_icon ? '2' : '1'
-    let extract_line_number = ':$(echo {' . object_name_index . "} | grep -o '[^:]*$')"
-    let preview_opts[-1] = preview_opts[-1][0:-3] . fnameescape(g:vista.source.fpath) . extract_line_number
-  endif
+    if has('win32')
+      " keeping old code around since we are not sure if / how preview works on windows
+      let preview_opts[-1] = preview_opts[-1][0:-3] . g:vista.source.fpath . (g:vista#renderer#enable_icon ? ':{2}' : ':{1}')
+    else
+      let object_name_index = g:vista#renderer#enable_icon ? '2' : '1'
+      let extract_line_number = ':$(echo {' . object_name_index . "} | grep -o '[^:]*$')"
+      let preview_opts[-1] = preview_opts[-1][0:-3] . fnameescape(g:vista.source.fpath) . extract_line_number
+    endif
 
-  call extend(opts.options, preview_opts)
+    call extend(opts.options, preview_opts)
+  endif
 
   return opts
 endfunction


### PR DESCRIPTION
After https://github.com/liuchengxu/vista.vim/pull/330 has been merged, the FZF preview window is forcibly displayed even though the `g:vista_fzf_preview` isn't configured.
This PR makes the FZF preview window be displayed only when it's needed (when `g:vista_fzf_preview` is configured).