### PR TITLE
Fixing with flag vista_close_on_fzf_select

### DIFF
--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -220,9 +220,6 @@ function! vista#(bang, ...) abort
   if a:0 == 0
     call vista#sidebar#Open()
     return
-  elseif vista#sidebar#IsOpen()
-    call vista#sidebar#Close()
-    return
   endif
 
   if a:0 == 1

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -94,9 +94,6 @@ function! vista#finder#fzf#sink(line, ...) abort
   call cursor(lnum, col)
   normal! zz
   call call('vista#util#Blink', get(g:, 'vista_blink', [2, 100]))
-  if g:vista_close_on_fzf_select
-    call vista#sidebar#Close()
-  endif
 endfunction
 
 " Actually call fzf#run() with a highlighter given the opts
@@ -187,6 +184,9 @@ endfunction
 " Optional argument: executive, coc or ctags
 " Ctags is the default.
 function! vista#finder#fzf#Run(...) abort
+  if g:vista_close_on_fzf_select
+    call vista#sidebar#Close()
+  endif
   if !exists('*fzf#run')
     return vista#error#Need('https://github.com/junegunn/fzf')
   endif


### PR DESCRIPTION
Issue [385](https://github.com/liuchengxu/vista.vim/issues/385)

# What
it closes the sidebar  when the finder is executed and remove the close sentence if the command `:Vista` doesn't
have arguments

# Why
After the PR [391](https://github.com/liuchengxu/vista.vim/pull/391) the flag continues with the issue as it is commented by  [derekschrock](https://github.com/liuchengxu/vista.vim/issues/385#issuecomment-786708985)

# Proof
[video explanation](https://www.youtube.com/watch?v=vxD96e-2uRU)

