### PR TITLE
[fix] jump to a line contains regex escape charactors may failed

### DIFF
--- a/autoload/vista/jump.vim
+++ b/autoload/vista/jump.vim
@@ -2,7 +2,7 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
-function! s:EscapeForVimRegexp(str)
+function! s:EscapeForVimRegexp(str) abort
   return escape(a:str, '^$.*?/\[]')
 endfunction
 

--- a/autoload/vista/jump.vim
+++ b/autoload/vista/jump.vim
@@ -2,6 +2,10 @@
 " MIT License
 " vim: ts=2 sw=2 sts=2 et
 
+function! s:EscapeForVimRegexp(str)
+  return escape(a:str, '^$.*?/\[]')
+endfunction
+
 " Jump to the source line containing the given tag
 function! vista#jump#TagLine(tag) abort
   let cur_line = split(getline('.'), ':')
@@ -19,7 +23,7 @@ function! vista#jump#TagLine(tag) abort
   endif
 
   try
-    let [_, start, _] = matchstrpos(line[0], a:tag)
+    let [_, start, _] = matchstrpos(line[0], s:EscapeForVimRegexp(a:tag))
   catch /^Vim\%((\a\+)\)\=:E869/
     let start  = -1
   endtry


### PR DESCRIPTION
if tag contains regex charactors (such as / - $ etc), may matchstrpos maybe failed.

if tag is [4-2] , matchstrpos will throw error blow:
```
Error detected while processing function vista#cursor#FoldOrJump[9]..vista#jump#TagLine:                                                                                              
line   16:
E944: Reverse range in character class
```