### PR TITLE
Option for hiding text kind when icons enabled (#408)

### DIFF
--- a/autoload/vista/renderer.vim
+++ b/autoload/vista/renderer.vim
@@ -49,6 +49,7 @@ let g:vista#renderer#ctags = get(g:, 'vista#renderer#ctags', 'default')
 let g:vista#renderer#icons = map(extend(s:icons, get(g:, 'vista#renderer#icons', {})), 'tolower(v:val)')
 let g:vista#renderer#enable_icon = get(g:, 'vista#renderer#enable_icon',
       \ exists('g:vista#renderer#icons') || exists('g:airline_powerline_fonts'))
+let g:vista#renderer#enable_kind = get(g:, 'vista#renderer#enable_kind', !g:vista#renderer#enable_icon)
 
 function! vista#renderer#IconFor(kind) abort
   if g:vista#renderer#enable_icon
@@ -58,6 +59,14 @@ function! vista#renderer#IconFor(kind) abort
     else
       return get(g:vista#renderer#icons, 'default', '?')
     endif
+  else
+    return ''
+  endif
+endfunction
+
+function! vista#renderer#KindFor(kind) abort
+  if g:vista#renderer#enable_kind
+    return a:kind
   else
     return ''
   endif

--- a/autoload/vista/renderer/hir/ctags.vim
+++ b/autoload/vista/renderer/hir/ctags.vim
@@ -21,14 +21,18 @@ function! s:Assemble(line, depth) abort
   let line = a:line
 
   let kind = get(line, 'kind', '')
+  let kind_icon = vista#renderer#IconFor(kind)
+  let kind_icon = empty(kind_icon) ? '' : kind_icon.' '
+  let kind_text = vista#renderer#KindFor(kind)
+  let kind_text = empty(kind_text) ? '' : ' '.kind_text
 
   let row = vista#util#Join(
         \ repeat(' ', a:depth * s:indent_size),
         \ s:GetVisibility(line),
-        \ vista#renderer#IconFor(kind).' ',
+        \ kind_icon,
         \ get(line, 'name'),
         \ get(line, 'signature', ''),
-        \ ' '.kind,
+        \ kind_text,
         \ ':'.get(line, 'line', '')
         \ )
 

--- a/autoload/vista/renderer/hir/lsp.vim
+++ b/autoload/vista/renderer/hir/lsp.vim
@@ -5,10 +5,20 @@
 let s:indent_size = g:vista#renderer#enable_icon ? 2 : 4
 
 function! s:IntoLSPHirRow(row) abort
-  let icon = vista#renderer#IconFor(a:row.kind).' '
-  let indented = repeat(' ', a:row.level * s:indent_size).icon.a:row.text.' '.a:row.kind
-  let lnum = ':'.a:row.lnum
-  return indented.lnum
+  let indent = repeat(' ', a:row.level * s:indent_size)
+  let kind_icon = vista#renderer#IconFor(a:row.kind)
+  let kind_text = vista#renderer#KindFor(a:row.kind)
+
+  " indent + kind_icon? + name + kind_text? + lnum
+  let line = indent
+  if !empty(kind_icon)
+    let line = line.kind_icon.' '
+  endif
+  let line = line.a:row.text
+  if !empty(kind_text)
+    let line = line.' '.kind_text
+  endif
+  return line.':'.a:row.lnum
 endfunction
 
 function! s:IntoLSPNonHirRow(row) abort

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -460,6 +460,13 @@ g:vista#renderer#enable_icon                        *g:vista#renderer#enable_ico
 
   Add pretty symbols for the kind of tags or LSP symbols.
 
+g:vista#renderer#enable_kind                        g:vista#renderer#enable_kind
+
+  Type: |Number|
+  Default: !g:vista#renderer#enable_icon
+
+  Show textual kind of tags or LSP symbols.
+
 g:vista_enable_markdown_extension              *g:vista_enable_markdown_extension*
 
   Type: |Number|


### PR DESCRIPTION
Pull request for: https://github.com/liuchengxu/vista.vim/issues/408

This PR adds a new option `g:vista#renderer#enable_kind` for hiding the textual representation of the kind. This option defaults to `!g:vista#renderer#enable_icon` because once icons are enabled the textual representation is redundant. Anyway, both options are compatible and users can enable both if they want.

I also, removed the extra spaces when the textual kind or icon kind are empty.

**SCREENSHOTS**

*coc, icon 1, kind 0*
![coc_icon_1_kind_0](https://user-images.githubusercontent.com/2648102/134778865-acd279be-f62b-4ede-adcb-522c51fd5481.png)

*coc, icon 1, kind 1*
![coc_icon_1_kind_1](https://user-images.githubusercontent.com/2648102/134778864-497978a5-fad0-4692-8c72-375f68792f64.png)

*ctags, icon 1, kind 0*
![ctags_icon_1_kind_0](https://user-images.githubusercontent.com/2648102/134778863-2deb3236-afb3-475a-a94f-2ab8aa7401dc.png)

*ctags, icon 1, kind 1*
![ctags_icon_1_kind_1](https://user-images.githubusercontent.com/2648102/134778862-1d12f659-f02a-41d0-a580-f515b6bef47d.png)
