### PR TITLE
Fix Fuzzy Finder search when element contains colon

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -159,7 +159,7 @@ function! vista#finder#PrepareOpts(source, prompt) abort
   let opts = {
           \ 'source': a:source,
           \ 'sink': function('vista#finder#fzf#sink'),
-          \ 'options': ['--prompt', a:prompt, '--nth', '1', '--delimiter', ':'] + get(g:, 'vista_fzf_opt', []),
+          \ 'options': ['--prompt', a:prompt, '--nth', '..-2', '--delimiter', ':'] + get(g:, 'vista_fzf_opt', []),
           \ }
 
   if len(g:vista_fzf_preview) > 0


### PR DESCRIPTION
LSP objects in Vista during FZF search are displayed as
<element>:<line_number>. In the Fuzzy Finder search we wanted search
only over the <element> part. It was achieved by defining search target
as everything up to the first colon. Such behavior was problematic in
languages like C++, where colon is a valid character for LSP object name
(it's denoting namespaces). For names like MyNamespace::MyClass::method
fuzzy finding didn't work properly and we could only search by the text
up to first colon.

The problem was fixed by changing the line number delimiter to be
the last colon.