### PR TITLE
Added a skip_once_flag to skip updating once

### DIFF
--- a/autoload/vista.vim
+++ b/autoload/vista.vim
@@ -16,9 +16,14 @@ let s:ignore_list = ['vista', 'vista_kind', 'nerdtree', 'startify', 'tagbar', 'f
 
 " Skip special buffers, filetypes.
 function! vista#ShouldSkip() abort
-  return !empty(&buftype)
-        \ || empty(&filetype)
-        \ || index(s:ignore_list, &filetype) > -1
+  if exists('g:vista.skip_once_flag') && g:vista.skip_once_flag
+    let g:vista.skip_once_flag = v:false
+    return v:true
+  else
+    return !empty(&buftype)
+          \ || empty(&filetype)
+          \ || index(s:ignore_list, &filetype) > -1
+  endif
 endfunction
 
 " Ignore some kinds of tags/symbols which is done at the parser step.

--- a/autoload/vista/init.vim
+++ b/autoload/vista/init.vim
@@ -80,5 +80,8 @@ function! vista#init#Api() abort
 
   let g:vista.source = source_handle
 
+  " Skip an update once with this flag
+  let g:vista.skip_once_flag = v:false
+
   hi default link VistaFloat Pmenu
 endfunction

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -142,6 +142,7 @@ function! vista#sidebar#ToggleFocus() abort
   if winnr != winnr()
     execute winnr.'wincmd w'
   else
+    let g:vista.skip_once_flag = v:true
     execute g:vista.source.get_winnr().'wincmd w'
   endif
 endfunction

--- a/autoload/vista/sidebar.vim
+++ b/autoload/vista/sidebar.vim
@@ -142,8 +142,7 @@ function! vista#sidebar#ToggleFocus() abort
   if winnr != winnr()
     execute winnr.'wincmd w'
   else
-    let g:vista.skip_once_flag = v:true
-    execute g:vista.source.get_winnr().'wincmd w'
+    call vista#source#GotoWin()
   endif
 endfunction
 

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -27,6 +27,7 @@ else
 endif
 
 function! vista#source#GotoWin() abort
+  let g:vista.skip_once_flag = v:true
   call s:GotoSourceWindow()
 
   " Floating window relys on BufEnter event to be closed automatically.


### PR DESCRIPTION
Addresses #430.

This avoids updating the Vista sidebar just once with on BufEnter. This is enough to at least get `:Vista focus` to stop resetting the sidebar.