### PR TITLE
Enhancement: add floating border config option

### DIFF
--- a/autoload/vista/floating.vim
+++ b/autoload/vista/floating.vim
@@ -135,6 +135,8 @@ function! s:Display(msg, win_id) abort
   let s:floating_opened_pos = getpos('.')
   let [width, height, anchor, row, col] = s:CalculatePosition(a:msg)
 
+  let border = g:vista_floating_border
+
   " silent is neccessary for the both strategy!
   silent let s:floating_win_id = nvim_open_win(
         \ s:floating_bufnr, v:true, {
@@ -145,6 +147,7 @@ function! s:Display(msg, win_id) abort
         \   'row': row + 0.4,
         \   'col': col - 5,
         \   'focusable': v:false,
+        \   'border': border,
         \ })
 
   call nvim_buf_set_lines(s:floating_bufnr, 0, -1, 0, a:msg)

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -445,6 +445,14 @@ g:vista_highlight_whole_line                        *g:vista_highlight_whole_lin
   By default vista.vim will try to highlight the tag precisely in the vista window.
   Set this to `1` to always higlight the whole line.
 
+
+g:vista_floating_border                      *g:vista_floating_border*
+
+  Type: |String|
+  Default: `none`
+
+  See `nvim_open_win` for border options that may be used.
+
 g:vista_floating_delay                                    *g:vista_floating_delay*
 
   Type: |Number|

--- a/plugin/vista.vim
+++ b/plugin/vista.vim
@@ -9,6 +9,7 @@ endif
 
 let g:loaded_vista = 1
 
+let g:vista_floating_border = get(g:, 'vista_floating_border', 'none')
 let g:vista_sidebar_width = get(g:, 'vista_sidebar_width', 30)
 let g:vista_sidebar_position = get(g:, 'vista_sidebar_position', 'vertical botright')
 let g:vista_blink = get(g:, 'vista_blink', [2, 100])


### PR DESCRIPTION
Closes #432 

Add `g:vista_floating_border` option which allows the user to change the border that vista uses for the floating preview.

Screenshot where I configured my neovim to use the `rounded` option:
![Screenshot_20220720_175429](https://user-images.githubusercontent.com/13339630/180107175-2be372ab-9688-4bd2-9bf5-21f861af0f50.png)

