### PR TITLE
fix: Ignore E803 error while trying to delete temporary highlight

### DIFF
--- a/autoload/vista/highlight.vim
+++ b/autoload/vista/highlight.vim
@@ -9,7 +9,11 @@
 " optional: tag - accurate tag
 function! vista#highlight#Add(lnum, ensure_visible, tag) abort
   if exists('w:vista_highlight_id')
-    call matchdelete(w:vista_highlight_id)
+    try
+      call matchdelete(w:vista_highlight_id)
+    catch /E803/
+      " ignore E803 error: ID not found
+    endtry
     unlet w:vista_highlight_id
   endif
 


### PR DESCRIPTION
Fixes a bug where the following E803 error happens as soon as the blinking highlight disappears.

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/1009873/203474519-60939a95-53f9-4ce4-81ab-ea10d6e88c17.png">
