### PR TITLE
Echo error explicitly

### DIFF
--- a/autoload/vista/executive/ctags.vim
+++ b/autoload/vista/executive/ctags.vim
@@ -177,6 +177,11 @@ if has('nvim')
       return
     endif
 
+    if self.stderr != ['']
+      call vista#error#(join(self.stderr, "\n"))
+      return
+    endif
+
     if self.stdout == ['']
       return
     endif
@@ -202,6 +207,12 @@ else
 
   function! s:close_cb(channel) abort
     call s:PrepareContainer()
+
+    if ch_status(a:channel, {'part': 'err'}) ==# 'buffered'
+      let line = ch_read(a:channel, {'part': 'err'})
+      call vista#error#(line)
+      return
+    endif
 
     while ch_status(a:channel, {'part': 'out'}) ==# 'buffered'
       let line = ch_read(a:channel)


### PR DESCRIPTION
Hi @liuchengxu, 非常感谢你创建了这么 Nice 的插件，不过在使用途中发现一些小小的问题，比如我自定义了 ruby 文件使用 `ripper-tags` 解析，但是因为我的 typo 我始终无法正确显示 ctags 侧边栏，最终花费了大量时间定位问题。

<img width="671" alt="image" src="https://user-images.githubusercontent.com/41264693/236237092-95b5cde2-a8e9-4970-ac1b-5c6487ce2754.png">

之前的异步处理没有处理错误情况，当 shell 命令失败之后直接静默掉，即使启用了 `g:vista_log_file` 也无法定位问题，这个 pr 增加了一些错误处理的逻辑，可以将错误直接提示给用户，减少用户发起 issue 的可能。

