### PR TITLE
Fix jump to wrong window in multi-tab

### DIFF
--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -4,7 +4,8 @@
 
 if exists('*bufwinid')
   function! s:GotoSourceWindow() abort
-    let winid = g:vista.source.get_winid()
+    let bufid = g:vista.source.bufnr
+    let winid = bufwinid(bufid)
     if winid != -1
       if win_getid() != winid
         " No use noautocmd here. Ref #362


### PR DESCRIPTION
The winid tracked in g:vista.source is not correct. So use g:vista.source.bufnr to get the correct winid and jump.

Close #416 