### PR TITLE
Avoid multi-line symbols

### DIFF
--- a/autoload/vista/parser/lsp.vim
+++ b/autoload/vista/parser/lsp.vim
@@ -89,10 +89,16 @@ function! vista#parser#lsp#CocSymbols(symbol, container) abort
     call add(g:vista.functions, a:symbol)
   endif
 
+  let symbol_text = a:symbol.text
+  let line_break_position = stridx(symbol_text, "\n")
+  if line_break_position != -1
+    let symbol_text = symbol_text[ : line_break_position - 1 ]
+  endif
+
   call add(a:container, {
         \ 'lnum': a:symbol.lnum,
         \ 'col': a:symbol.col,
-        \ 'text': a:symbol.text,
+        \ 'text': symbol_text,
         \ 'kind': a:symbol.kind,
         \ 'level': a:symbol.level
         \ })


### PR DESCRIPTION
When the symbol text is multi-line, the behavior when hovering the cursor is not correct.

This pull request is a fix for symbol text not being multi-line.