### PR TITLE
Remove s from asm kinds option

### DIFF
--- a/autoload/vista/types/uctags/asm.vim
+++ b/autoload/vista/types/uctags/asm.vim
@@ -6,7 +6,6 @@ let s:types.lang = 'asm'
 let s:types.kinds = {
     \ 'm': {'long' : 'macros',    'fold' : 0, 'stl' : 1},
     \ 't': {'long' : 'types',     'fold' : 0, 'stl' : 1},
-    \ 's': {'long' : 'sections',  'fold' : 0, 'stl' : 1},
     \ 'd': {'long' : 'defines',   'fold' : 0, 'stl' : 1},
     \ 'l': {'long' : 'labels',    'fold' : 0, 'stl' : 1}
     \ }


### PR DESCRIPTION
check https://docs.ctags.io/en/latest/news/6-1-0.html#changes-about-parser-specific-kinds-roles-fields-and-extras

> - Asm
>   - section kind is deleted.

and https://docs.ctags.io/en/latest/man/ctags-lang-asm.7.html#change-since-0-0



  

>   The kind section is deleted. The section specified with .section directive as tagged as placement role of section kind of Asm language. These kind and role are deleted.
> 
>     Instead, it is tagged as destination role of inputSection kind of LdScript language.

with `section` kind, you'll get:
`[vista.vim] ctags: Warning: Unsupported kind: 's' for --asm-kinds option`