### PR TITLE
Jump to latest windows when using FZF in vista finder.

### DIFF
--- a/autoload/vista/finder.vim
+++ b/autoload/vista/finder.vim
@@ -225,6 +225,8 @@ function! vista#finder#RunFZFOrSkim(apply_run) abort
 endfunction
 
 function! vista#finder#Dispatch(bang, finder, executive) abort
+  " This is the entry point for finder. Save currenbt window
+  let g:vista.prev_win_id = win_getid()
   let finder = empty(a:finder) ? 'fzf' : a:finder
   if empty(a:executive)
     let executive = vista#GetExplicitExecutiveOrDefault()

--- a/autoload/vista/finder/fzf.vim
+++ b/autoload/vista/finder/fzf.vim
@@ -83,6 +83,11 @@ function! vista#finder#fzf#sink(line, ...) abort
   let col = stridx(g:vista.source.line(lnum), tag)
   let col = col == -1 ? 1 : col + 1
   if a:0 > 0
+
+    echomsg "Parameters for vista sink:"
+    echomsg a:0
+    echomsg a:1
+
     if win_getid() != a:1
       noautocmd call win_gotoid(a:1)
     endif

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -5,7 +5,16 @@
 if exists('*bufwinid')
   function! s:GotoSourceWindow() abort
     let bufid = g:vista.source.bufnr
-    let winid = bufwinid(bufid)
+    let winids = win_findbuf(g:vista.source.bufnr)
+
+    " Use previous window if var exists or fallback to bufsinid() to get first
+    " window with buffer
+    if exists('g:vista.prev_win_id') && index(winids, g:vista.prev_win_id) >= 0
+      let winid = g:vista.prev_win_id
+    else
+      let winid = bufwinid(bufid)
+    endif
+
     if winid != -1
       if win_getid() != winid
         " No use noautocmd here. Ref #362

--- a/autoload/vista/source.vim
+++ b/autoload/vista/source.vim
@@ -7,9 +7,9 @@ if exists('*bufwinid')
     let bufid = g:vista.source.bufnr
     let winids = win_findbuf(g:vista.source.bufnr)
 
-    " Use previous window if var exists or fallback to bufsinid() to get first
-    " window with buffer
-    if exists('g:vista.prev_win_id') && index(winids, g:vista.prev_win_id) >= 0
+    " Use previous window if var exists or fallback to bufwinid() to get first window with buffer
+    " Enable this behaviour with g:vista_fzf_jump_to_last_used_win
+    if (exists('g:vista_fzf_jump_to_last_used_win') && g:vista_fzf_jump_to_last_used_win == 1)  && (exists('g:vista.prev_win_id') && index(winids, g:vista.prev_win_id) >= 0)
       let winid = g:vista.prev_win_id
     else
       let winid = bufwinid(bufid)

--- a/doc/vista.txt
+++ b/doc/vista.txt
@@ -535,6 +535,16 @@ g:vista_enable_centering_jump                      *g:vista_enable_centering_jum
   Set this variable to `0` to not make the line at center of window when you
   jump to the tag.
 
+g:vista_fzf_jump_to_last_used_win              *g:vista_fzf_jump_to_last_used_win*
+
+  Type: |Number|
+  Default: `0`
+
+  Whether or not FZF jumps to latest used window for buffer, or first window
+  for buffer. This is useful when using severeail windows for the same buffers.
+  The default is to always jump to first window for the buffer.
+
+
 --------------------------------------------------------------------------------
 Key Mappings                                                  *vista-key-mappings*
 


### PR DESCRIPTION
When using Vista finder to select a symbol in  a FZF window, the `sink()` callback for FZF is designed to use `bufwinid()` by default
which returns the first window opened for the buffer.
If you have the buffer opened in two or more windows it doesn't matter from what window you call Vista finder, FZF will always jump to the first window for the buffer instead instead of the latest used window, the window from where you call Vista finder.

This PR adds a new variable: **g:vista_fzf_jump_to_last_used_win** .
When set to 1 the sink() function in FZF will jump to the latest used window instead of the first.